### PR TITLE
[KIP-37] fix typo and add mintBatch method at KIP37Mintable extension

### DIFF
--- a/KIPs/kip-37.md
+++ b/KIPs/kip-37.md
@@ -724,7 +724,7 @@ interface IKIP37Mintable {
         uint256 _quantity
     ) external;
 
-    /// @notice Mints tokens in a batch and assigns the tokens according to the variables `_to` and `_quantities`.
+    /// @notice Mints tokens in a batch and assigns the tokens according to the variables `_toList` and `_quantities`.
     /// @dev Throws if `msg.sender` is not allowed to mint.
     ///   MUST emit an event `TransferSingle` or `TransferBatch`.
     /// @param _id The token id to mint.

--- a/KIPs/kip-37.md
+++ b/KIPs/kip-37.md
@@ -170,15 +170,15 @@ This section describes the differences between KIP-37 and ERC-1155.
 
 The below table shows KIP-13 identifiers for interfaces defined in this proposal.
 
-|Interface|KIP-13 Identifier|
-|---|---|
-|[IKIP37](#kip37-interface)|0x6433ca1f|
-|[IKIP37TokenReceiver](#kip-37-token-receiver)|0x7cc2d017|
-|[IERC1155TokenReceiver](#kip-37-token-receiver)|0x4e2312e0|
-|[IKIP37Metadata](#metadata-extension)|0x0e89341c|
-|[IKIP37Mintable](#minting-extension)|0x84aec3b9|
-|[IKIP37Burnable](#burning-extension)|0x9e094e9e|
-|[IKIP37Pausable](#pausing-extension)|0xe8ffdb7|
+| Interface                                       | KIP-13 Identifier |
+| ----------------------------------------------- | ----------------- |
+| [IKIP37](#kip37-interface)                      | 0x6433ca1f        |
+| [IKIP37TokenReceiver](#kip-37-token-receiver)   | 0x7cc2d017        |
+| [IERC1155TokenReceiver](#kip-37-token-receiver) | 0x4e2312e0        |
+| [IKIP37Metadata](#metadata-extension)           | 0x0e89341c        |
+| [IKIP37Mintable](#minting-extension)            | 0x84aec3b9        |
+| [IKIP37Burnable](#burning-extension)            | 0x9e094e9e        |
+| [IKIP37Pausable](#pausing-extension)            | 0x0e8ffdb7        |
 
 ### KIP-37 Token Receiver
 
@@ -712,15 +712,27 @@ interface IKIP37Mintable {
         string calldata _uri
     ) external returns (bool);
 
+    /// @notice Mints token and assigns the token according to the variables `_to` and `_quantity`.
+    /// @dev Throws if `msg.sender` is not allowed to mint.
+    ///   MUST emit an event `TransferSingle`.
+    /// @param _id The token id to mint.
+    /// @param _to The address that will receive the minted token.
+    /// @param _quantity The quantity of token being minted.
+    function mint(
+        uint256 _id,
+        address _to,
+        uint256 _quantity
+    ) external;
+
     /// @notice Mints tokens in a batch and assigns the tokens according to the variables `_to` and `_quantities`.
     /// @dev Throws if `msg.sender` is not allowed to mint.
     ///   MUST emit an event `TransferSingle` or `TransferBatch`.
     /// @param _id The token id to mint.
-    /// @param _to The list of addresses that will receive the minted tokens.
+    /// @param _toList The list of addresses that will receive the minted tokens.
     /// @param _quantities The list of quantities of tokens being minted.
-    function mint(
+    function mintBatch(
         uint256 _id,
-        address[] calldata _to,
+        address[] calldata _toList,
         uint256[] calldata _quantities
     ) external;
 }
@@ -778,13 +790,13 @@ The optional `KIP37Pausable` extension can be identified with the (KIP-13 Standa
 
 If the optional `KIP37Pausable` extension is included:
 
-- The KIP-13 `supportsInterface` function MUST return the constant value `true` if `0xe8ffdb7` is passed through the `interfaceID` argument.
+- The KIP-13 `supportsInterface` function MUST return the constant value `true` if `0x0e8ffdb7` is passed through the `interfaceID` argument.
 
 ```solidity
 pragma solidity 0.5.6;
 
 /// @title KIP-37 Multi Token Standard, optional pausing extension
-///  Note: the KIP-13 identifier for this interface is 0xe8ffdb7.
+///  Note: the KIP-13 identifier for this interface is 0x0e8ffdb7.
 interface IKIP37Pausable {
     /// @notice Checks whether the whole contract is paused.
     /// @return True if the contract is paused, false otherwise.

--- a/KIPs/kip-37.md
+++ b/KIPs/kip-37.md
@@ -176,7 +176,7 @@ The below table shows KIP-13 identifiers for interfaces defined in this proposal
 | [IKIP37TokenReceiver](#kip-37-token-receiver)   | 0x7cc2d017        |
 | [IERC1155TokenReceiver](#kip-37-token-receiver) | 0x4e2312e0        |
 | [IKIP37Metadata](#metadata-extension)           | 0x0e89341c        |
-| [IKIP37Mintable](#minting-extension)            | 0x84aec3b9        |
+| [IKIP37Mintable](#minting-extension)            | 0xdc25b845        |
 | [IKIP37Burnable](#burning-extension)            | 0x9e094e9e        |
 | [IKIP37Pausable](#pausing-extension)            | 0x0e8ffdb7        |
 
@@ -686,7 +686,7 @@ The optional `KIP37Mintable` extension can be identified with the (KIP-13 Standa
 
 If the optional `KIP37Mintable` extension is included:
 
-- The KIP-13 `supportsInterface` function MUST return the constant value `true` if `0x84aec3b9` is passed through the `interfaceID` argument.
+- The KIP-13 `supportsInterface` function MUST return the constant value `true` if `0xdc25b845` is passed through the `interfaceID` argument.
 - The `create` function is used to create a new token allocated with a new token id.
   - An implementation MUST emit the `URI` event during a create operation if the created token has its own metadata.
 - When creating tokens, the total supply of the token ID must be increased by initial supply.
@@ -697,7 +697,7 @@ If the optional `KIP37Mintable` extension is included:
 pragma solidity 0.5.6;
 
 /// @title KIP-37 Multi Token Standard, optional minting extension
-///  Note: the KIP-13 identifier for this interface is 0x84aec3b9.
+///  Note: the KIP-13 identifier for this interface is 0xdc25b845.
 interface IKIP37Mintable {
     /// @notice Creates a new token type and assigns _initialSupply to the minter.
     /// @dev Throws if `msg.sender` is not allowed to create.

--- a/KIPs/kip-37.md
+++ b/KIPs/kip-37.md
@@ -737,7 +737,7 @@ interface IKIP37Mintable {
         uint256[] calldata _values
     ) external;
 
-    /// @notice Mints multiple KIP37 tokens of the specific token types `_ids` in a batch and assigns the tokens according to the variables `_to` and `_values`.
+    /// @notice Mints multiple KIP-37 tokens of the specific token types `_ids` in a batch and assigns the tokens according to the variables `_to` and `_values`.
     /// @dev Throws if `msg.sender` is not allowed to mint.
     ///   MUST emit one or more `TransferSingle` events or a single `TransferBatch` event.
     ///   MUST revert if the length of `_ids` is not the same as the length of `_values`.

--- a/KIPs/kip-37.md
+++ b/KIPs/kip-37.md
@@ -176,7 +176,7 @@ The below table shows KIP-13 identifiers for interfaces defined in this proposal
 | [IKIP37TokenReceiver](#kip-37-token-receiver)   | 0x7cc2d017        |
 | [IERC1155TokenReceiver](#kip-37-token-receiver) | 0x4e2312e0        |
 | [IKIP37Metadata](#metadata-extension)           | 0x0e89341c        |
-| [IKIP37Mintable](#minting-extension)            | 0xdc25b845        |
+| [IKIP37Mintable](#minting-extension)            | 0xdfd9d9ec        |
 | [IKIP37Burnable](#burning-extension)            | 0x9e094e9e        |
 | [IKIP37Pausable](#pausing-extension)            | 0x0e8ffdb7        |
 
@@ -686,7 +686,7 @@ The optional `KIP37Mintable` extension can be identified with the (KIP-13 Standa
 
 If the optional `KIP37Mintable` extension is included:
 
-- The KIP-13 `supportsInterface` function MUST return the constant value `true` if `0xdc25b845` is passed through the `interfaceID` argument.
+- The KIP-13 `supportsInterface` function MUST return the constant value `true` if `0xdfd9d9ec` is passed through the `interfaceID` argument.
 - The `create` function is used to create a new token allocated with a new token id.
   - An implementation MUST emit the `URI` event during a create operation if the created token has its own metadata.
 - When creating tokens, the total supply of the token ID must be increased by initial supply.
@@ -697,7 +697,7 @@ If the optional `KIP37Mintable` extension is included:
 pragma solidity 0.5.6;
 
 /// @title KIP-37 Multi Token Standard, optional minting extension
-///  Note: the KIP-13 identifier for this interface is 0xdc25b845.
+///  Note: the KIP-13 identifier for this interface is 0xdfd9d9ec.
 interface IKIP37Mintable {
     /// @notice Creates a new token type and assigns _initialSupply to the minter.
     /// @dev Throws if `msg.sender` is not allowed to create.
@@ -712,28 +712,42 @@ interface IKIP37Mintable {
         string calldata _uri
     ) external returns (bool);
 
-    /// @notice Mints tokens of the specific token type `_id` and assigns the tokens according to the variables `_to` and `_quantity`.
+    /// @notice Mints tokens of the specific token type `_id` and assigns the tokens according to the variables `_to` and `_value`.
     /// @dev Throws if `msg.sender` is not allowed to mint.
     ///   MUST emit an event `TransferSingle`.
     /// @param _id The token id to mint.
     /// @param _to The address that will receive the minted tokens.
-    /// @param _quantity The quantity of tokens being minted.
+    /// @param _value The quantity of tokens being minted.
     function mint(
         uint256 _id,
         address _to,
-        uint256 _quantity
+        uint256 _value
     ) external;
 
-    /// @notice Mints tokens of the specific token type `_id` in a batch and assigns the tokens according to the variables `_toList` and `_quantities`.
+    /// @notice Mints tokens of the specific token type `_id` in a batch and assigns the tokens according to the variables `_toList` and `_values`.
     /// @dev Throws if `msg.sender` is not allowed to mint.
-    ///   MUST emit one or more `TransferSingle` events or a single `TransferBatch` event.
+    ///   MUST emit one or more `TransferSingle` events.
+    ///   MUST revert if the length of `_toList` is not the same as the length of `_values`.
     /// @param _id The token id to mint.
     /// @param _toList The list of addresses that will receive the minted tokens.
-    /// @param _quantities The list of quantities of tokens being minted.
-    function mintBatch(
+    /// @param _values The list of quantities of tokens being minted.
+    function mint(
         uint256 _id,
         address[] calldata _toList,
-        uint256[] calldata _quantities
+        uint256[] calldata _values
+    ) external;
+
+    /// @notice Mints multiple KIP37 tokens of the specific token types `_ids` in a batch and assigns the tokens according to the variables `_to` and `_values`.
+    /// @dev Throws if `msg.sender` is not allowed to mint.
+    ///   MUST emit one or more `TransferSingle` events or a single `TransferBatch` event.
+    ///   MUST revert if the length of `_ids` is not the same as the length of `_values`.
+    /// @param _to The address that will receive the minted tokens.
+    /// @param _ids The list of the token ids to mint.
+    /// @param _values The list of quantities of tokens being minted.
+    function mintBatch(
+        address _to,
+        uint256[] calldata _ids,
+        uint256[] calldata _values
     ) external;
 }
 ```

--- a/KIPs/kip-37.md
+++ b/KIPs/kip-37.md
@@ -716,7 +716,7 @@ interface IKIP37Mintable {
     /// @dev Throws if `msg.sender` is not allowed to mint.
     ///   MUST emit an event `TransferSingle`.
     /// @param _id The token id to mint.
-    /// @param _to The address that will receive the minted token.
+    /// @param _to The address that will receive the minted tokens.
     /// @param _quantity The quantity of token being minted.
     function mint(
         uint256 _id,

--- a/KIPs/kip-37.md
+++ b/KIPs/kip-37.md
@@ -712,7 +712,7 @@ interface IKIP37Mintable {
         string calldata _uri
     ) external returns (bool);
 
-    /// @notice Mints token and assigns the token according to the variables `_to` and `_quantity`.
+    /// @notice Mints tokens of the specific token type `_id` and assigns the tokens according to the variables `_to` and `_quantity`.
     /// @dev Throws if `msg.sender` is not allowed to mint.
     ///   MUST emit an event `TransferSingle`.
     /// @param _id The token id to mint.

--- a/KIPs/kip-37.md
+++ b/KIPs/kip-37.md
@@ -717,7 +717,7 @@ interface IKIP37Mintable {
     ///   MUST emit an event `TransferSingle`.
     /// @param _id The token id to mint.
     /// @param _to The address that will receive the minted tokens.
-    /// @param _quantity The quantity of token being minted.
+    /// @param _quantity The quantity of tokens being minted.
     function mint(
         uint256 _id,
         address _to,

--- a/KIPs/kip-37.md
+++ b/KIPs/kip-37.md
@@ -726,7 +726,7 @@ interface IKIP37Mintable {
 
     /// @notice Mints tokens in a batch and assigns the tokens according to the variables `_toList` and `_quantities`.
     /// @dev Throws if `msg.sender` is not allowed to mint.
-    ///   MUST emit an event `TransferSingle` or `TransferBatch`.
+    ///   MUST emit one or more `TransferSingle`events or a single `TransferBatch` event.
     /// @param _id The token id to mint.
     /// @param _toList The list of addresses that will receive the minted tokens.
     /// @param _quantities The list of quantities of tokens being minted.

--- a/KIPs/kip-37.md
+++ b/KIPs/kip-37.md
@@ -724,7 +724,7 @@ interface IKIP37Mintable {
         uint256 _quantity
     ) external;
 
-    /// @notice Mints tokens in a batch and assigns the tokens according to the variables `_toList` and `_quantities`.
+    /// @notice Mints tokens of the specific token type `_id` in a batch and assigns the tokens according to the variables `_toList` and `_quantities`.
     /// @dev Throws if `msg.sender` is not allowed to mint.
     ///   MUST emit one or more `TransferSingle` events or a single `TransferBatch` event.
     /// @param _id The token id to mint.

--- a/KIPs/kip-37.md
+++ b/KIPs/kip-37.md
@@ -726,7 +726,7 @@ interface IKIP37Mintable {
 
     /// @notice Mints tokens in a batch and assigns the tokens according to the variables `_toList` and `_quantities`.
     /// @dev Throws if `msg.sender` is not allowed to mint.
-    ///   MUST emit one or more `TransferSingle`events or a single `TransferBatch` event.
+    ///   MUST emit one or more `TransferSingle` events or a single `TransferBatch` event.
     /// @param _id The token id to mint.
     /// @param _toList The list of addresses that will receive the minted tokens.
     /// @param _quantities The list of quantities of tokens being minted.


### PR DESCRIPTION
This PR fix the multi token standard.
- Fix the KIP-13 identifier value of IKIP37Pausable from '0xe8ffdb7' to '0x0e8ffdb7'.
- Reflect the previous review 'add mintBatch method at KIP37Mintable extension'.