### PR TITLE
[KIP-114] Signature-based random in block headers

### DIFF
--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -161,10 +161,11 @@ However, in reality, there is a possibility of collusion among validators that f
 
 ### Tips for application developers
 
-In Cypress, the proposer is selected in a round-robin manner; all validators get an equal chance to propose in each round. Users of this random should be aware that in the worst-case scenario where only a single validator remains benign, the colluding validators can predict ahead by up to twice the number of colluding validators (i.e., when benign validator proposes first in the first round and last in the second round). Note that this number may differ should the proposer selection algorithm change.
+In Cypress, the proposer is selected in a round-robin manner; all validators get an equal chance to propose in each round. Users of this random should be aware that in the worst-case scenario where only a single validator remains benign, the colluding validators can predict the value of `mixHash` ahead by up to twice the number of colluding validators (i.e., when benign validator proposes first in the first round and last in the second round). Note that this number may differ should the proposer selection algorithm change.
 
 After the activation of [KIP-146](https://github.com/klaytn/kips/blob/kip114/KIPs/kip-146.md), the predictable window size increases.
 Define `f(x, N, C) = (C/N)^x` as the probability of `C` number of colluding validators becoming proposers for `x` consecutive blocks among `N` validators.
+By definition, with the probability of `f`, colluding validators can predict the value of `mixHash` `x` blocks in advance.
 Here are some varying combinations of `N`, `C`, and `threshold`, which developers can refer to for choosing the security level.
 
 | N   | C   | x where f(x, N, C) < 0.001 | x where f(x, N, C) < 0.0001 |

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -160,48 +160,25 @@ Therefore, in theory, no one (including the proposer of the block `N`) can predi
 
 However, in reality, there is a possibility of collusion among validators that facilitates the prediction beyond the ideal situation. Specifically, colluding validators can share their `randomReveal`s in advance to enable the precomputation of `mixHash`. The extent to which colluding validators can predict depends on the number of consecutive blocks they collectively propose; the more the validators collude, the further they can predict. A single benign validator can disrupt the collusion, thereby limiting the predictable timeframe.
 
-Define `f(x, numVals, numCols)` as the probability of `numCols` number of colluding validators, among `numVals` validators, conspiring to predict the value of `mixHash` `x` blocks in advance.
-It implies that `numCols` number of colluding validators must become proposers for `x` consecutive blocks.
+Define `f(x, N, C)`:
+
+- `N`: the number of validators
+- `C`: the number of colluding validators (N > C)
+- `x`: the number of blocks from the latest block
+- `f`: the probability of predicting the value of `mixHash` `x` blocks in advance. In other words, the probability of colluding validators becoming proposers for `x` consecutive blocks.
 
 #### Before KIP-146
 
 The proposer is selected in a round-robin manner; all validators get an equal chance to propose in each round. Users of this random should be aware that in the worst-case scenario where only a single validator remains benign, the colluding validators can predict the value of `mixHash` ahead by up to twice the number of colluding validators (i.e., when benign validator proposes first in the first round and last in the second round).
-In other words, `f(x, numVals, numCols)` is zero when `x >= 2*numVals` and `numVals > numCols`.
+In other words, `f(x, N, C)` is zero when `x >= 2*N` and `N > C`.
 
 #### After KIP-146
 
-After KIP-146, the proposer is randomly selected after each block, thus `f(x, numVals, numCols) = (numCols/numVals)^x`.
+After KIP-146, the proposer is randomly selected after each block, thus `f(x, N, C) = (C/N)^x`.
 
 ### Tips for application developers
 
-Before KIP-146, developers are advised to give a window of twice the number of validators between the commit and reveal block when using commit-reveal random schemes using `mixHash`.
-
-After KIP-146, there is no theoretical bound to which `mixHash` becomes unpredictable. Here are some varying combinations of `N`, `C`, and `threshold`, which developers can refer to for choosing the security level.
-
-| numVals | numCols | x where f(x, numVals, numCols) < 0.001 | x where f(x, numVals, numCols) < 0.0001 |
-| ------- | ------- | -------------------------------------- | --------------------------------------- |
-| 30      | 1       | 3                                      | 3                                       |
-| 30      | 21      | 20                                     | 26                                      |
-| 30      | 29      | 204                                    | 272                                     |
-| 100     | 1       | 2                                      | 3                                       |
-| 100     | 10      | 4                                      | 5                                       |
-| 100     | 50      | 10                                     | 14                                      |
-| 100     | 67      | 18                                     | 23                                      |
-| 100     | 99      | 688                                    | 917                                     |
-
-Here is the script for developers that wish to customize the variables:
-
-```python
-def f(x, numVals, numCols):
-    return (numCols / numVals) ** x
-
-
-def find(numVals, numCols, threshold):
-    print(numVals, numCols, threshold)
-    for x in range(10000000):
-        if f(x, numVals, numCols) < threshold:
-            return x
-```
+After KIP-146, there is no theoretical bound to which `mixHash` becomes unpredictable. Thus, we must set a practical threshold. Given that IBFT permits one third of the validators to be malicious, developers are advised to give a window of 200 blocks to be "95 nines" safe.
 
 ## Implementation
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -159,43 +159,52 @@ Therefore, in theory, no one (including the proposer of the block `N`) can predi
 
 However, in reality, there is a possibility of collusion among validators that facilitates the prediction beyond the ideal situation. Specifically, colluding validators can share their `randomReveal`s in advance to enable the precomputation of `mixHash`. The extent to which colluding validators can predict depends on the number of consecutive blocks they collectively propose; the more the validators collude, the further they can predict. A single benign validator can disrupt the collusion, thereby limiting the predictable timeframe.
 
+Define `f(x, numVals, numCols)` as the probability of `numCols` number of colluding validators, among `numVals` validators, conspiring to predict the value of `mixHash` `x` blocks in advance.
+It implies that `numCols` number of colluding validators must become proposers for `x` consecutive blocks.
+
+#### Before KIP-146
+
+The proposer is selected in a round-robin manner; all validators get an equal chance to propose in each round. Users of this random should be aware that in the worst-case scenario where only a single validator remains benign, the colluding validators can predict the value of `mixHash` ahead by up to twice the number of colluding validators (i.e., when benign validator proposes first in the first round and last in the second round).
+In other words, `f(x, numVals, numCols)` is zero when `x >= 2*numVals` and `numVals > numCols`.
+
+#### After KIP-146
+
+After KIP-146, the proposer is randomly selected after each block, thus `f(x, numVals, numCols) = (numCols/numVals)^x`.
+
 ### Tips for application developers
 
-In Cypress, the proposer is selected in a round-robin manner; all validators get an equal chance to propose in each round. Users of this random should be aware that in the worst-case scenario where only a single validator remains benign, the colluding validators can predict the value of `mixHash` ahead by up to twice the number of colluding validators (i.e., when benign validator proposes first in the first round and last in the second round). Note that this number may differ should the proposer selection algorithm change.
+Before KIP-146, developers are advised to give a window of twice the number of validators between the commit and reveal block when using commit-reveal random schemes using `mixHash`.
 
-After the activation of [KIP-146](https://github.com/klaytn/kips/blob/kip114/KIPs/kip-146.md), the predictable window size increases.
-Define `f(x, N, C) = (C/N)^x` as the probability of `C` number of colluding validators, among `N` validators, conspiring to predict the value of `mixHash` `x` blocks in advance.
-It implies that `C` number of colluding validators must become proposers for `x` consecutive blocks.
-Here are some varying combinations of `N`, `C`, and `threshold`, which developers can refer to for choosing the security level.
+After KIP-146, there is no theoretical bound to which `mixHash` becomes unpredictable. Here are some varying combinations of `N`, `C`, and `threshold`, which developers can refer to for choosing the security level.
 
-| N   | C   | x where f(x, N, C) < 0.001 | x where f(x, N, C) < 0.0001 |
-| --- | --- | -------------------------- | --------------------------- |
-| 30  | 1   | 3                          | 3                           |
-| 30  | 21  | 20                         | 26                          |
-| 30  | 29  | 204                        | 272                         |
-| 100 | 1   | 2                          | 3                           |
-| 100 | 10  | 4                          | 5                           |
-| 100 | 50  | 10                         | 14                          |
-| 100 | 67  | 18                         | 23                          |
-| 100 | 99  | 688                        | 917                         |
+| numVals | numCols | x where f(x, numVals, numCols) < 0.001 | x where f(x, numVals, numCols) < 0.0001 |
+| ------- | ------- | -------------------------------------- | --------------------------------------- |
+| 30      | 1       | 3                                      | 3                                       |
+| 30      | 21      | 20                                     | 26                                      |
+| 30      | 29      | 204                                    | 272                                     |
+| 100     | 1       | 2                                      | 3                                       |
+| 100     | 10      | 4                                      | 5                                       |
+| 100     | 50      | 10                                     | 14                                      |
+| 100     | 67      | 18                                     | 23                                      |
+| 100     | 99      | 688                                    | 917                                     |
 
 Here is the script for developers that wish to customize the variables:
 
 ```python
-def f(x, N, C):
-    return (C / N) ** x
+def f(x, numVals, numCols):
+    return (numCols / numVals) ** x
 
 
-def find(N, C, threshold):
-    print(N, C, threshold)
+def find(numVals, numCols, threshold):
+    print(numVals, numCols, threshold)
     for x in range(10000000):
-        if f(x, N, C) < threshold:
+        if f(x, numVals, numCols) < threshold:
             return x
 ```
 
 ## Implementation
 
-A simpulation in Python:
+A simulation in Python:
 
 ```python
 from blspy import PrivateKey, G1Element, G2Element, PopSchemeMPL  # blspy

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -100,7 +100,8 @@ def calc_mix_hash(prevMixHash, randomReveal):
     return xor(prevMixHash, keccak256(randomReveal))
 
 def verify_kip114_header(header, prevHeader):
-    [proposerPubkey, proposerPop] = getProposerPubkeyPop()
+    # Getting PoP information from the smart contract registry defined in KIP-113.
+    [proposerPubkey, proposerPop] = get_proposer_pubkey_pop()
     # pop verify
     pop_verify(proposerPubkey, proposerPop)
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -273,7 +273,7 @@ However, in reality, there is a possibility of collusion among validators that f
 
 ### Tips for application developers
 
-In Cypress, the proposer is selected in a round-robin manner; all validators get an equal chance to propose in each round. Users of this random should be aware that in the worst-case scenario where only a single validator remains benign, the colluding validators can predict ahead by up to twice the number of colluding validators (i.e., when benign validator proposes first in the first round and last in the second round). Note that this number can vary depending on the proposer selection algorithm.
+In Cypress, the proposer is selected in a round-robin manner; all validators get an equal chance to propose in each round. Users of this random should be aware that in the worst-case scenario where only a single validator remains benign, the colluding validators can predict ahead by up to twice the number of colluding validators (i.e., when benign validator proposes first in the first round and last in the second round). Note that this number may differ should the proposer selection algorithm change.
 
 ## References
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -37,7 +37,7 @@ In this proposal, new header fields `randomReveal` and `mixHash` are introduced.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
 
-The terms hash\*to_point (denoted by hash), public key, proof-of-possession (denoted by pop) are from the ciphersuite [BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP\_](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-4.2.3).
+The terms hash_to_point (denoted by hash), public key, proof-of-possession (denoted by pop) are from the ciphersuite [BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP\_](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-4.2.3).
 
 ## Parameters
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -285,6 +285,35 @@ However, in reality, there is a possibility of collusion among validators that f
 
 In Cypress, the proposer is selected in a round-robin manner; all validators get an equal chance to propose in each round. Users of this random should be aware that in the worst-case scenario where only a single validator remains benign, the colluding validators can predict ahead by up to twice the number of colluding validators (i.e., when benign validator proposes first in the first round and last in the second round). Note that this number may differ should the proposer selection algorithm change.
 
+After the activation of [KIP-146](https://github.com/klaytn/kips/blob/kip114/KIPs/kip-146.md), the predictable window size increases.
+Define `f(x, N, C) = (C/N)^x` as the probability of `C` number of colluding validators becoming proposers for `x` consecutive blocks among `N` validators.
+Here are some varying combinations of `N`, `C`, and `threshold`, which developers can refer to for choosing the security level.
+
+| N   | C   | x where f(x, N, C) < 0.001 | x where f(x, N, C) < 0.0001 |
+| --- | --- | -------------------------- | --------------------------- |
+| 30  | 1   | 3                          | 3                           |
+| 30  | 21  | 20                         | 26                          |
+| 30  | 29  | 204                        | 272                         |
+| 100 | 1   | 2                          | 3                           |
+| 100 | 10  | 4                          | 5                           |
+| 100 | 50  | 10                         | 14                          |
+| 100 | 67  | 18                         | 23                          |
+| 100 | 99  | 688                        | 917                         |
+
+Here is the script for developers that wish to customize the variables:
+
+```python
+def f(x, N, C):
+    return (C / N) ** x
+
+
+def find(N, C, threshold):
+    print(N, C, threshold)
+    for x in range(10000000):
+        if f(x, N, C) < threshold:
+            return x
+```
+
 ## References
 
 - [consensus-specs/beacon-chain.md at dev · ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#randao)

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -164,8 +164,8 @@ However, in reality, there is a possibility of collusion among validators that f
 In Cypress, the proposer is selected in a round-robin manner; all validators get an equal chance to propose in each round. Users of this random should be aware that in the worst-case scenario where only a single validator remains benign, the colluding validators can predict the value of `mixHash` ahead by up to twice the number of colluding validators (i.e., when benign validator proposes first in the first round and last in the second round). Note that this number may differ should the proposer selection algorithm change.
 
 After the activation of [KIP-146](https://github.com/klaytn/kips/blob/kip114/KIPs/kip-146.md), the predictable window size increases.
-Define `f(x, N, C) = (C/N)^x` as the probability of `C` number of colluding validators becoming proposers for `x` consecutive blocks among `N` validators.
-By definition, with the probability of `f`, colluding validators can predict the value of `mixHash` `x` blocks in advance.
+Define `f(x, N, C) = (C/N)^x` as the probability of `C` number of colluding validators, among `N` validators, conspiring to predict the value of `mixHash` `x` blocks in advance.
+It implies that `C` number of colluding validators must become proposers for `x` consecutive blocks.
 Here are some varying combinations of `N`, `C`, and `threshold`, which developers can refer to for choosing the security level.
 
 | N   | C   | x where f(x, N, C) < 0.001 | x where f(x, N, C) < 0.0001 |

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -1,6 +1,6 @@
 ---
 kip: 114
-title: Signature-based random in block headers
+title: Supplant DIFFICULTY opcode with RANDOM
 author: Ian (@ian0371), Ollie (@blukat29), Joseph (@jiseongnoh), and Aidan (@aidan-kwon)
 discussions-to: https://github.com/klaytn/kips/issues/114
 status: Draft
@@ -11,11 +11,11 @@ created: 2023-05-31
 
 ## Simple Summary
 
-New fields in the block header as the source of on-chain random
+Introduce on-chain randomness and expose it in the EVM by supplanting DIFFICULTY opcode semantics
 
 ## Abstract
 
-This standard outlines an approach for generating an on-chain random value based on digital signature. Specifically, it introduces new fields, namely `randomReveal` and `mixHash`, in the block header; `randomReveal` is a verifiable random number, and `mixHash` is a derivation from a mixture of `randomReveals` and additional information. They serve as an unpredictable, verifiable, and dependable source of on-chain randomness.
+This standard outlines an approach for generating an on-chain random value based on digital signature. Specifically, it introduces new fields, namely `randomReveal` and `mixHash`, in the block header; `randomReveal` is a verifiable random number, and `mixHash` is a derivation from a mixture of `randomReveals` and additional information. They serve as an unpredictable, verifiable, and dependable source of on-chain randomness. In addition, these fields can be fetched from the EVM via `RANDOM (0x44)` opcode.
 
 ## Motivation
 
@@ -65,6 +65,11 @@ Beginning with `FORK_BLOCK`, the proposer must fill the new fields in the block 
 
 - `mixHash`: The proposer must XOR the keccak256 hash of `randomReveal` and the previous block's `mixHash`. If the previous block's `mixHash` is null (e.g., previous block is before `FORK_BLOCK`), then use 32 bytes of zero instead.
 
+```python
+header.randomReveal = sign(privateKey, header.number)
+header.mixHash = xor(prevHeader.mixHash, keccak256(randomReveal))
+```
+
 #### Validation
 
 Beginning with `FORK_BLOCK`, validators must validate the new fields:
@@ -99,23 +104,30 @@ def calc_random_reveal(privateKey, headerNumber):
 def calc_mix_hash(prevMixHash, randomReveal):
     return xor(prevMixHash, keccak256(randomReveal))
 
-def verify_kip114_header(header, prevHeader):
+def verify_kip114_header(newHeader, prevHeader):
     # Getting PoP information from the smart contract registry defined in KIP-113.
     [proposerPubkey, proposerPop] = get_proposer_pubkey_pop()
     # pop verify
-    pop_verify(proposerPubkey, proposerPop)
+    if not pop_verify(proposerPubkey, proposerPop):
+        return False
 
     # signature verify
-    if not verify(proposerPubkey, header.number, header.randomReveal):
+    if not verify(proposerPubkey, newHeader.number, newHeader.randomReveal):
         return False
 
     # mixHash verify
-    if header.number == FORK_BLOCK:
+    if newHeader.number == FORK_BLOCK:
         prevMixHash = DEFAULT_MIXHASH
     else:
         prevMixHash = prevHeader.mixHash
-    return header.mixHash == calc_mix_hash(prevMixHash, header.randomReveal):
+    return newHeader.mixHash == calc_mix_hash(prevMixHash, newHeader.randomReveal):
 ```
+
+### EVM
+
+Beginning with `FORK_BLOCK`, the `RANDOM (0x44)` instruction must return the value of `mixHash` of the latest block.
+
+Note: The gas cost of the `RANDOM (0x44)` opcode remains unchanged.
 
 ### Genesis Block
 
@@ -151,14 +163,10 @@ BLS signature as well as the signing message (i.e., proposing block number) is d
 
 ### Predictability
 
-`mixHash` of the block number `N` can be computed only when these values are revealed:
+A list of inputs influencing future randomness consists of but is not limited to the following items:
 
-- `mixHash` of the block `N-1`.
-- `randomReveal` of the block `N`.
-
-Therefore, in theory, no one (including the proposer of the block `N`) can predict the value of `mixHash` of the block `N` before the block `N-1` has been finalized.
-
-However, in reality, there is a possibility of collusion among validators that facilitates the prediction beyond the ideal situation. Specifically, colluding validators can share their `randomReveal`s in advance to enable the precomputation of `mixHash`. The extent to which colluding validators can predict depends on the number of consecutive blocks they collectively propose; the more the validators collude, the further they can predict. A single benign validator can disrupt the collusion, thereby limiting the predictable timeframe.
+- **Number of colluding validators.** When colluding validators become proposers of consecutive blocks, they collectively share their `randomReveal`s in advance to predict the value of `mixHash`.
+- **Proposer selection policy.** This contributes to how likely the colluding validators become proposers of consecutive blocks.
 
 Define `f(x, N, C)`:
 
@@ -167,18 +175,13 @@ Define `f(x, N, C)`:
 - `x`: the number of blocks from the latest block
 - `f`: the probability of predicting the value of `mixHash` `x` blocks in advance. In other words, the probability of colluding validators becoming proposers for `x` consecutive blocks.
 
-#### Before KIP-146
-
-The proposer is selected in a round-robin manner; all validators get an equal chance to propose in each round. Users of this random should be aware that in the worst-case scenario where only a single validator remains benign, the colluding validators can predict the value of `mixHash` ahead by up to twice the number of colluding validators (i.e., when benign validator proposes first in the first round and last in the second round).
-In other words, `f(x, N, C)` is zero when `x >= 2*N` and `N > C`.
-
-#### After KIP-146
-
-After KIP-146, the proposer is randomly selected after each block, thus `f(x, N, C) = (C/N)^x`.
+Under random proposer selection policy, the proposer is randomly selected after each block, thus `f(x, N, C) = (C/N)^x`.
 
 ### Tips for application developers
 
-After KIP-146, there is no theoretical bound to which `mixHash` becomes unpredictable. Thus, we must set a practical threshold. Given that IBFT permits one third of the validators to be malicious, developers are advised to give a window of 200 blocks to be "95 nines" safe.
+The following tips attempt to reduce predictability and biasability of randomness outputs returned by `RANDOM (0x44)`:
+
+- Make your applications rely on the future randomness with a reasonably high lookahead. Given that IBFT permits one third of the validators to be malicious, developers are advised to give a distance of 200 blocks between bidding and rolling the dice to be "95 nines" safe.
 
 ## Implementation
 
@@ -249,13 +252,13 @@ class BLSRegistry:
         return self.mapping[addr]
 
 
-def is_kip114_fork_enabled(num):
+def is_kip114_fork_enabled(num) -> bool:
     return FORK_BLOCK <= num
 
 
 # dummy function for fetching the proposer secret key
 # in implementation, this should be fetched from a file
-def get_proposer_private_key(num):
+def get_proposer_private_key(num) -> PrivateKey:
     proposerIdx = num % validatorNum
     return proposerBLSPrivKeys[proposerIdx]
 
@@ -275,7 +278,7 @@ def calc_random_reveal(sk, num) -> bytes:
     return bytes(PopSchemeMPL.sign(sk, msg))
 
 
-def calc_mix_hash(prevMixHash, randomReveal):
+def calc_mix_hash(prevMixHash, randomReveal) -> bytes:
     return xor(prevMixHash, keccak256(randomReveal))
 
 
@@ -289,7 +292,7 @@ def gen_next_header(prevHeader) -> Header:
     return newHeader
 
 
-def keccak256(msg):
+def keccak256(msg) -> bytes:
     keccak256 = keccak.new(digest_bits=256)
     keccak256.update(msg)
     return keccak256.digest()
@@ -299,11 +302,11 @@ def block_num_to_bytes(num) -> bytes:
     return num.to_bytes(8, byteorder="big")
 
 
-def xor(a: bytes, b: bytes):
+def xor(a: bytes, b: bytes) -> bytes:
     return bytes(x ^ y for x, y in zip(a, b))
 
 
-def verify_kip114_header(header, prevHeader):
+def verify_kip114_header(header, prevHeader) -> bool:
     if not is_kip114_fork_enabled(header.number):
         return True
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -191,10 +191,10 @@ def calc_random_reveal(sk, num) -> bytes:
 
 
 def calc_mix_hash(parentMixHash, randomReveal):
-    return xorBytes(parentMixHash, keccak256(randomReveal))
+    return xor(parentMixHash, keccak256(randomReveal))
 
 
-def xorBytes(a: bytes, b: bytes):
+def xor(a: bytes, b: bytes):
     return bytes(x ^ y for x, y in zip(a, b))
 
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -269,7 +269,7 @@ BLS signature as well as the signing message (i.e., proposing block number) is d
 
 `mixHash` of the next block can be computed when the both requirements are met: (1) the `mixHash` of the latest block is revealed; and (2) the `randomReveal` of the next block is revealed. Even if the proposer of the next block can precompute the latter as soon as the proposer found out that it is proposing the next block, it does not know the former which circumvents the proposer from predicting `mixHash` of the next block. In other words, only after the proposer receives the latest `mixHash`, it is able to know the `mixHash` of the next block.
 
-However, in reality, there is a possibility of collusion among validators that facilitates the prediction beyond the ideal situation. Specifically, colluding validators can share their `randomReveal`s in advance which enables the precomputation of `mixHash`. The extent to which colluding validators can predict depends on the number of consecutive blocks they collectively propose; the more the validators collude, the further they can predict. A single benign validator can disrupt the collusion, thereby limiting the predictable timeframe.
+However, in reality, there is a possibility of collusion among validators that facilitates the prediction beyond the ideal situation. Specifically, colluding validators can share their `randomReveal`s in advance to enable the precomputation of `mixHash`. The extent to which colluding validators can predict depends on the number of consecutive blocks they collectively propose; the more the validators collude, the further they can predict. A single benign validator can disrupt the collusion, thereby limiting the predictable timeframe.
 
 ### Tips for application developers
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -1,0 +1,269 @@
+---
+kip: 114
+title: Signature-based random in block headers
+author: Ian (@ian0371), Ollie (@blukat29), Joseph (@jiseongnoh), and Aidan (@aidan-kwon)
+discussions-to: https://github.com/klaytn/kips/issues/114
+status: Draft
+type: Standards Track
+category: Core
+created: 2023-05-31
+---
+
+## Simple Summary
+
+## Abstract
+
+This standard outlines an approach for generating an on-chain random value based on digital signature. Specifically, it introduces new fields, namely `randomReveal` and `mixHash`, in the block header; `randomReveal` is a verifiable random number, and `mixHash` is a derivation from a mixture of `randomReveals` and additional information. They serve as an unpredictable, verifiable, and dependable source of on-chain randomness.
+
+## Motivation
+
+An unpredictable, verifiable, and dependable on-chain randomness can be utilized in various use-cases including the protocol and applications.
+
+- Unpredictability indicates that the random should be as difficult to predict as possible.
+
+- Verifiability ensures that the random is authentic and cannot be manipulated or forged.
+
+- Dependability implies that the random is generated without trusting any external sources of randomness, such as oracles.
+
+An example of such randomness is proposer selection. An exemplary requirement can be that the next block's proposer remains undisclosed until the latest block has been finalized, or that the proposer cannot tamper with deciding the next block's proposer.
+
+In this proposal, new header fields `randomReveal` and `mixHash` are introduced. `randomReveal` is the signature of the proposer, and `randomReveal`s are mixed to compute `mixHash`, which users can use for the random source. `mixHash` is unpredictable, verifiable, and dependable:
+
+- (Unpredictability) the signature is random and so is `mixHash`.
+- (Verifiability) the signature can be verified with the public key of the proposer, and `mixHash` is computed in a deterministic manner.
+- (Dependability) `mixHash` only relies on the validators.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+The terms hash\*to_point (denoted by hash), public key, proof-of-possession (denoted by pop) are from the ciphersuite [BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP\_](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-4.2.3).
+
+## Parameters
+
+| Constant     | Value |
+| ------------ | ----- |
+| `FORK_BLOCK` | TBD   |
+
+## Block Structure
+
+Beginning with `FORK_BLOCK`, client software must set the fields in a block header:
+
+- `randomReveal`: 96 bytes. It must be specified in the 15th field (0-indexed) of a block header.
+
+- `mixHash`: 32 bytes. It must be specified in the 16th field (0-indexed) of a block header.
+
+## Block Processing
+
+### Block Proposal
+
+Beginning with `FORK_BLOCK`, the proposer must fill the new fields in the block proposal:
+
+- `randomReveal`: The proposer must sign the hash of the next block number.
+
+- `mixHash`: The proposer must XOR the keccak256 hash of `randomReveal` and the previous block's `mixHash`. If the previous block is before `FORK_BLOCK`, then the latter must be 32 bytes of zero.
+
+### Validation
+
+Beginning with `FORK_BLOCK`, validators must validate the new fields:
+
+- `randomReveal`
+
+  - The validators must fetch the public key and the pop of the proposer by `getInfo(cnNodeId)` of the BLS registry standardized by [KIP-113](https://github.com/klaytn/kips/blob/main/KIPs/kip-113.md#validation).
+  - The validators must verify the validity of the proposer public key using pop as mentioned in [here](https://github.com/klaytn/kips/blob/main/KIPs/kip-113.md#validation).
+  - The validators must verify if `randomReveal` is signed by the proposer public key.
+
+- `mixHash`: The validators must verify the validity of the proposed `mixHash` by calculating `mixHash` using the aforementioned `mixHasH` algorithm.
+
+### Pseudocode
+
+See the following pseudocode that implements the block processing in python:
+
+```python
+from blspy import PrivateKey, G1Element, G2Element, PopSchemeMPL  # blspy
+from Crypto.Hash import keccak  # pycryptodome
+
+FORK_BLOCK = 100  # TBD
+
+validatorNum: int = 3
+proposerBLSPrivKeys: list[PrivateKey] = [
+    PrivateKey.from_bytes((i + 1).to_bytes(32, byteorder="big"))
+    for i in range(validatorNum)
+]  # b"\x00..\x01", b"\x00..\x02", ...
+proposerBLSPublicKeys: list[G1Element] = [i.get_g1() for i in proposerBLSPrivKeys]
+proposerAddrs: list[str] = [
+    str(i + 1).zfill(40) for i in range(validatorNum)
+]  # "0x00..1, 0x00..2, ..."
+
+
+# Block header. Only relevant fields are shown here.
+class Header:
+    number: int = 0  # Block number
+    randomReveal: bytes
+    mixHash: bytes
+    proposer: str
+
+    def __init__(self, number: int, randomReveal: bytes, mixHash: bytes):
+        self.number = number
+        self.randomReveal = randomReveal
+        self.mixHash = mixHash
+        self.proposer = proposerAddrs[number % validatorNum]
+
+    def __repr__(self):
+        return "number: {}\n\nrandomReveal ({} bytes): {}\n\nmixHash ({} bytes): {}".format(
+            self.number,
+            len(self.randomReveal),
+            self.randomReveal,
+            len(self.mixHash),
+            self.mixHash,
+        )
+
+
+class BlsPublicKeyInfo:
+    publicKey: bytes
+    pop: bytes
+
+    def __init__(self, publicKey, pop):
+        self.publicKey = publicKey
+        self.pop = pop
+
+
+# A BLSRegistry that supports the interface IKIP-113 (https://github.com/klaytn/kips/blob/main/KIPs/kip-113.md)
+class BLSRegistry:
+    mapping = {}
+
+    def __init__(self):
+        for i, proposerAddr in enumerate(proposerAddrs):
+            pop = bytes(PopSchemeMPL.pop_prove(proposerBLSPrivKeys[i]))
+            self.mapping[proposerAddr] = BlsPublicKeyInfo(
+                bytes(proposerBLSPublicKeys[i]), pop
+            )
+
+    def getInfo(self, addr: str) -> BlsPublicKeyInfo:
+        return self.mapping[addr]
+
+
+def is_xxxx_fork_enabled(num):
+    return FORK_BLOCK <= num
+
+
+# dummy function for fetching the proposer secret key
+# in implementation, this should be fetched from a file
+def get_proposer_sk(num):
+    proposerIdx = num % validatorNum
+    return proposerBLSPrivKeys[proposerIdx]
+
+
+def gen_next_header(parent) -> Header:
+    nextBlockNum = parent.number + 1
+    if is_xxxx_fork_enabled(nextBlockNum):
+        sk = get_proposer_sk(nextBlockNum)
+
+        randomReveal = calc_random_reveal(sk, nextBlockNum)
+
+        if nextBlockNum == FORK_BLOCK:
+            # parent mixHash does not exist, so fill with default
+            parentMixHash = b"\x00" * 32
+        else:
+            parentMixHash = parent.mixHash
+
+        mixHash = calc_mix_hash(parentMixHash, randomReveal)
+    else:
+        randomReveal = b""
+        mixHash = b""
+
+    return Header(nextBlockNum, randomReveal, mixHash)
+
+
+def keccak256(msg):
+    keccak256 = keccak.new(digest_bits=256)
+    keccak256.update(msg)
+    return keccak256.digest()
+
+
+def block_num_to_bytes(num) -> bytes:
+    return num.to_bytes(8, byteorder="big")
+
+
+def calc_random_reveal(sk, num) -> bytes:
+    msg = block_num_to_bytes(num)
+    return bytes(PopSchemeMPL.sign(sk, msg))
+
+
+def calc_mix_hash(parentMixHash, randomReveal):
+    return xorBytes(parentMixHash, keccak256(randomReveal))
+
+
+def xorBytes(a: bytes, b: bytes):
+    return bytes(x ^ y for x, y in zip(a, b))
+
+
+def validatePubkey(pubkey, pop):
+    pass
+
+
+def verify_xxxx_header(header):
+    if not is_xxxx_fork_enabled(header.number):
+        return True
+
+    # pop verify
+    blsPublicKeyInfo = BLSRegistry().getInfo(header.proposer)
+    publicKey = G1Element.from_bytes(blsPublicKeyInfo.publicKey)
+    pop = G2Element.from_bytes(blsPublicKeyInfo.pop)
+    if not PopSchemeMPL.pop_verify(publicKey, pop):
+        return False
+
+    # sig verify
+    msg = block_num_to_bytes(header.number)
+    sig = G2Element.from_bytes(header.randomReveal)
+    return PopSchemeMPL.verify(publicKey, msg, sig)
+
+
+def main():
+    header = Header(FORK_BLOCK - 2, b"\x04" * 96, b"\x01" * 32)
+    N = 10
+    # print header numbers in [FORK_BLOCK - 1, FORK_BLOCK + N]
+    for _ in range(N + 2):
+        header = gen_next_header(header)
+        print(header)
+        verified = verify_xxxx_header(header)
+        assert verified
+        print("verified:", verified)
+        print("=" * 80)
+
+
+main()
+```
+
+### Genesis Block
+
+If `FORK_BLOCK` is zero, the genesis block must have `randomReveal`, `mixHash` fields.
+
+## Rationale
+
+### Names of the header fields
+
+The naming is highly inspired by [EIP-4339](https://eips.ethereum.org/EIPS/eip-4399).
+We use `randomReveal` instead of RANDAO reveal because the randoms are generated in a different manner.
+
+### Block size increment due to new fields in the header
+
+The size increment cost of RLP-encoded header is around 131 bytes per block, which is approximately 3.8GB per year. It is a negligible cost compared to its benefit.
+
+### BLS-VRF over EC-VRF
+
+For later consensus changes
+
+## Backwards Compatibility
+
+Blocks before `FORK_BLOCK` will remain the same.
+
+## References
+
+- [consensus-specs/beacon-chain.md at dev · ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#randao)
+- [EIP-4399: Supplant DIFFICULTY opcode with PREVRANDAO](https://eips.ethereum.org/EIPS/eip-4399)
+- [RANDAO algorithm](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#randao)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -245,7 +245,7 @@ main()
 
 ### Genesis Block
 
-If `FORK_BLOCK` is zero, the genesis block must have `randomReveal`, `mixHash` fields.
+If `FORK_BLOCK` is zero, the genesis block must have `randomReveal` and `mixHash` fields.
 
 ## Rationale
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -150,7 +150,12 @@ BLS signature as well as the signing message (i.e., proposing block number) is d
 
 ### Predictability
 
-`mixHash` of the next block can be computed when the both requirements are met: (1) the `mixHash` of the latest block is revealed; and (2) the `randomReveal` of the next block is revealed. Even if the proposer of the next block can precompute the latter as soon as the proposer found out that it is proposing the next block, it does not know the former which circumvents the proposer from predicting `mixHash` of the next block. In other words, only after the proposer receives the latest `mixHash`, it is able to know the `mixHash` of the next block.
+`mixHash` of the block number `N` can be computed only when these values are revealed:
+
+- `mixHash` of the block `N-1`.
+- `randomReveal` of the block `N`.
+
+Therefore, in theory, no one (including the proposer of the block `N`) can predict the value of `mixHash` of the block `N` before the block `N-1` has been finalized.
 
 However, in reality, there is a possibility of collusion among validators that facilitates the prediction beyond the ideal situation. Specifically, colluding validators can share their `randomReveal`s in advance to enable the precomputation of `mixHash`. The extent to which colluding validators can predict depends on the number of consecutive blocks they collectively propose; the more the validators collude, the further they can predict. A single benign validator can disrupt the collusion, thereby limiting the predictable timeframe.
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -279,7 +279,6 @@ In Cypress, the proposer is selected in a round-robin manner; all validators get
 
 - [consensus-specs/beacon-chain.md at dev · ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#randao)
 - [EIP-4399: Supplant DIFFICULTY opcode with PREVRANDAO](https://eips.ethereum.org/EIPS/eip-4399)
-- [RANDAO algorithm](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#randao)
 
 ## Copyright
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -37,7 +37,7 @@ In this proposal, new header fields `randomReveal` and `mixHash` are introduced.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
 
-The terms hash_to_point (hereinafter referred to as hash), public key, proof-of-possession (hereinafter referred to as pop) are from the ciphersuite [BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP\_](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-4.2.3).
+The terms hash_to_point (hereinafter referred to as hash), public key, proof-of-possession (hereinafter referred to as pop) are from the ciphersuite [BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP\_](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-4.2.3).
 
 ## Parameters
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -41,13 +41,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 The terms hash_to_point (hereinafter referred to as hash), public key, proof-of-possession (hereinafter referred to as pop) are from the ciphersuite [BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP\_](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-4.2.3).
 
-## Parameters
+### Parameters
 
 | Constant     | Value |
 | ------------ | ----- |
 | `FORK_BLOCK` | TBD   |
 
-## Block Structure
+### Block Structure
 
 Beginning with `FORK_BLOCK`, client software must set the fields in a block header:
 
@@ -55,9 +55,9 @@ Beginning with `FORK_BLOCK`, client software must set the fields in a block head
 
 - `mixHash`: 32 bytes. It must be specified in the 16th field (0-indexed) of a block header.
 
-## Block Processing
+### Block Processing
 
-### Block Proposal
+#### Block Proposal
 
 Beginning with `FORK_BLOCK`, the proposer must fill the new fields in the block proposal:
 
@@ -65,7 +65,7 @@ Beginning with `FORK_BLOCK`, the proposer must fill the new fields in the block 
 
 - `mixHash`: The proposer must XOR the keccak256 hash of `randomReveal` and the previous block's `mixHash`. If the previous block is before `FORK_BLOCK`, then the latter must be 32 bytes of zero.
 
-### Validation
+#### Validation
 
 Beginning with `FORK_BLOCK`, validators must validate the new fields:
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -66,6 +66,26 @@ Beginning with `FORK_BLOCK`, the proposer must fill the new fields in the block 
 - `mixHash`: The proposer must XOR the keccak256 hash of `randomReveal` and the previous block's `mixHash`. If the previous block's `mixHash` is null (e.g., previous block is before `FORK_BLOCK`), then use 32 bytes of zero instead.
 
 ```python
+class Header:
+	parentHash:   hash
+	rewardbase:   address
+	root:         hash
+	txHash:       hash
+	receiptHash:  hash
+	bloom:        bloom
+	blockScore:   int
+	number:       int
+	gasUsed:      uint64
+	time:         int
+	timeFoS:      uint8
+	extra:        bytes
+	governance:   bytes
+	vote:         bytes
+	baseFee:      int
+
+	randomReveal: bytes # new
+	mixHash:      bytes # new
+
 header.randomReveal = sign(privateKey, header.number)
 header.mixHash = xor(prevHeader.mixHash, keccak256(randomReveal))
 ```

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -37,7 +37,7 @@ In this proposal, new header fields `randomReveal` and `mixHash` are introduced.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
 
-The terms hash_to_point (denoted by hash), public key, proof-of-possession (denoted by pop) are from the ciphersuite [BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP\_](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-4.2.3).
+The terms hash_to_point (hereinafter referred to as hash), public key, proof-of-possession (hereinafter referred to as pop) are from the ciphersuite [BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP\_](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-4.2.3).
 
 ## Parameters
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -198,10 +198,6 @@ def xor(a: bytes, b: bytes):
     return bytes(x ^ y for x, y in zip(a, b))
 
 
-def validatePubkey(pubkey, pop):
-    pass
-
-
 def verify_xxxx_header(header):
     if not is_xxxx_fork_enabled(header.number):
         return True

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -11,6 +11,8 @@ created: 2023-05-31
 
 ## Simple Summary
 
+New fields in the block header as the source of on-chain random
+
 ## Abstract
 
 This standard outlines an approach for generating an on-chain random value based on digital signature. Specifically, it introduces new fields, namely `randomReveal` and `mixHash`, in the block header; `randomReveal` is a verifiable random number, and `mixHash` is a derivation from a mixture of `randomReveals` and additional information. They serve as an unpredictable, verifiable, and dependable source of on-chain randomness.
@@ -25,9 +27,9 @@ An unpredictable, verifiable, and dependable on-chain randomness can be utilized
 
 - Dependability implies that the random is generated without trusting any external sources of randomness, such as oracles.
 
-An example of such randomness is proposer selection. An exemplary requirement can be that the next block's proposer remains undisclosed until the latest block has been finalized, or that the proposer cannot tamper with deciding the next block's proposer.
+An example of such use-cases is the block proposer selection. An exemplary requirement can be that the next block's proposer remains undisclosed until the latest block has been finalized, or that the proposer cannot tamper with deciding the next block's proposer.
 
-In this proposal, new header fields `randomReveal` and `mixHash` are introduced. `randomReveal` is the signature of the proposer, and `randomReveal`s are mixed to compute `mixHash`, which users can use for the random source. `mixHash` is unpredictable, verifiable, and dependable:
+In this proposal, new header fields `randomReveal` and `mixHash` are introduced. `randomReveal` is the signature of the proposer, and `randomReveal`s are mixed to compute `mixHash`, which users can use for a part of the random source. `mixHash` is unpredictable, verifiable, and dependable:
 
 - (Unpredictability) the signature is random and so is `mixHash`.
 - (Verifiability) the signature can be verified with the public key of the proposer, and `mixHash` is computed in a deterministic manner.
@@ -59,7 +61,7 @@ Beginning with `FORK_BLOCK`, client software must set the fields in a block head
 
 Beginning with `FORK_BLOCK`, the proposer must fill the new fields in the block proposal:
 
-- `randomReveal`: The proposer must sign the hash of the next block number.
+- `randomReveal`: The proposer must sign the hash of the proposing block number.
 
 - `mixHash`: The proposer must XOR the keccak256 hash of `randomReveal` and the previous block's `mixHash`. If the previous block is before `FORK_BLOCK`, then the latter must be 32 bytes of zero.
 
@@ -73,7 +75,7 @@ Beginning with `FORK_BLOCK`, validators must validate the new fields:
   - The validators must verify the validity of the proposer public key using pop as mentioned in [here](https://github.com/klaytn/kips/blob/main/KIPs/kip-113.md#validation).
   - The validators must verify if `randomReveal` is signed by the proposer public key.
 
-- `mixHash`: The validators must verify the validity of the proposed `mixHash` by calculating `mixHash` using the aforementioned `mixHasH` algorithm.
+- `mixHash`: The validators must verify the validity of the proposed `mixHash` by calculating `mixHash` using the aforementioned `mixHash` algorithm.
 
 ### Pseudocode
 
@@ -250,12 +252,28 @@ The size increment cost of RLP-encoded header is around 131 bytes per block, whi
 
 We chose BLS-based verifiable random over EC-based because:
 
-- reference implementation can be found easier
-- in case the consensus changes to BLS signature-based in the future
+- A BLS library written in Golang is easy to find as in [link](https://github.com/klaytn/klaytn/issues/1823), whereas it is not the case for EC-based as in [link](https://www.ietf.org/archive/id/draft-irtf-cfrg-vrf-15.html#section-6).
+- There is a potential consensus change based on BLS signature. Therefore, this proposal gently introduces BLS signature to the Klaytn protocol as well as adding on-chain randomness.
 
 ## Backwards Compatibility
 
 Blocks before `FORK_BLOCK` will remain the same.
+
+## Security Considerations
+
+### Biasability
+
+BLS signature as well as the signing message (i.e., proposing block number) is deterministic. Thus, the proposer has no influence over the computation of `mixHash`. In addition, the biasability of `mixHash` mainly depends on that of the hash of `randomReveal`. To the best of our knowledge, keccak256 is not a biased hash function. Therefore, `mixHash`, which is the XOR of the output of keccak256 and the previous `mixHash`, is unbiased.
+
+### Predictability
+
+`mixHash` of the next block can be computed when the both requirements are met: (1) the `mixHash` of the latest block is revealed; and (2) the `randomReveal` of the next block is revealed. Even if the proposer of the next block can precompute the latter as soon as the proposer found out that it is proposing the next block, it does not know the former which circumvents the proposer from predicting `mixHash` of the next block. In other words, only after the proposer receives the latest `mixHash`, it is able to know the `mixHash` of the next block.
+
+However, in reality, there is a possibility of collusion among validators that facilitates the prediction beyond the ideal situation. Specifically, colluding validators can share their `randomReveal`s in advance which enables the precomputation of `mixHash`. The extent to which colluding validators can predict depends on the number of consecutive blocks they collectively propose; the more the validators collude, the further they can predict. A single benign validator can disrupt the collusion, thereby limiting the predictable timeframe.
+
+### Tips for application developers
+
+In Cypress, the proposer is selected in a round-robin manner; all validators get an equal chance to propose in each round. Users of this random should be aware that in the worst-case scenario where only a single validator remains benign, the colluding validators can predict ahead by up to twice the number of colluding validators (i.e., when benign validator proposes first in the first round and last in the second round). Note that this number can vary depending on the proposer selection algorithm.
 
 ## References
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -250,9 +250,12 @@ We use `randomReveal` instead of RANDAO reveal because the randoms are generated
 
 The size increment cost of RLP-encoded header is around 131 bytes per block, which is approximately 3.8GB per year. It is a negligible cost compared to its benefit.
 
-### BLS-VRF over EC-VRF
+### BLS-based random over EC-based random
 
-For later consensus changes
+We chose BLS-based verifiable random over EC-based because:
+
+- reference implementation can be found easier
+- in case the consensus changes to BLS signature-based in the future
 
 ## Backwards Compatibility
 

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -200,7 +200,7 @@ def xor(a: bytes, b: bytes):
     return bytes(x ^ y for x, y in zip(a, b))
 
 
-def verify_xxxx_header(header):
+def verify_xxxx_header(header, parentMixHash):
     if not is_xxxx_fork_enabled(header.number):
         return True
 
@@ -214,20 +214,30 @@ def verify_xxxx_header(header):
     # sig verify
     msg = block_num_to_bytes(header.number)
     sig = G2Element.from_bytes(header.randomReveal)
-    return PopSchemeMPL.verify(publicKey, msg, sig)
+    if not PopSchemeMPL.verify(publicKey, msg, sig):
+        return False
+
+    # mixHash verify
+    if header.number == FORK_BLOCK:
+        # parent mixHash does not exist, so fill with default
+        parentMixHash = b"\x00" * 32
+    mixHash = calc_mix_hash(parentMixHash, header.randomReveal)
+    return mixHash == header.mixHash
 
 
 def main():
-    header = Header(FORK_BLOCK - 2, b"\x04" * 96, b"\x01" * 32)
+    header = Header(FORK_BLOCK - 2, b"\x04" * 96, b"\x00" * 32)
+    prevHeader = header
     N = 10
     # print header numbers in [FORK_BLOCK - 1, FORK_BLOCK + N]
     for _ in range(N + 2):
         header = gen_next_header(header)
         print(header)
-        verified = verify_xxxx_header(header)
+        verified = verify_xxxx_header(header, prevHeader.mixHash)
         assert verified
         print("verified:", verified)
         print("=" * 80)
+        prevHeader = header
 
 
 main()

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -63,7 +63,7 @@ Beginning with `FORK_BLOCK`, the proposer must fill the new fields in the block 
 
 - `randomReveal`: The proposer must sign the hash of the proposing block number.
 
-- `mixHash`: The proposer must XOR the keccak256 hash of `randomReveal` and the previous block's `mixHash`. If the previous block is before `FORK_BLOCK`, then the latter must be 32 bytes of zero.
+- `mixHash`: The proposer must XOR the keccak256 hash of `randomReveal` and the previous block's `mixHash`. If the previous block's `mixHash` is null (e.g., previous block is before `FORK_BLOCK`), then use 32 bytes of zero instead.
 
 #### Validation
 
@@ -79,168 +79,41 @@ Beginning with `FORK_BLOCK`, validators must validate the new fields:
 
 ### Pseudocode
 
-See the following pseudocode that implements the block processing in python:
+See the following pseudocode that describes the block processing in python:
 
 ```python
-from blspy import PrivateKey, G1Element, G2Element, PopSchemeMPL  # blspy
-from Crypto.Hash import keccak  # pycryptodome
+DEFAULT_MIXHASH = b"\x00" * 32
 
-FORK_BLOCK = 100  # TBD
+def fill_kip114_header(newHeader, prevHeader, privateKey):
+    newHeader.randomReveal = calc_random_reveal(privateKey, newHeader.number)
 
-validatorNum: int = 3
-proposerBLSPrivKeys: list[PrivateKey] = [
-    PrivateKey.from_bytes((i + 1).to_bytes(32, byteorder="big"))
-    for i in range(validatorNum)
-]  # b"\x00..\x01", b"\x00..\x02", ...
-proposerBLSPublicKeys: list[G1Element] = [i.get_g1() for i in proposerBLSPrivKeys]
-proposerAddrs: list[str] = [
-    str(i + 1).zfill(40) for i in range(validatorNum)
-]  # "0x00..1, 0x00..2, ..."
-
-
-# Block header. Only relevant fields are shown here.
-class Header:
-    number: int = 0  # Block number
-    randomReveal: bytes
-    mixHash: bytes
-    proposer: str
-
-    def __init__(self, number: int, randomReveal: bytes, mixHash: bytes):
-        self.number = number
-        self.randomReveal = randomReveal
-        self.mixHash = mixHash
-        self.proposer = proposerAddrs[number % validatorNum]
-
-    def __repr__(self):
-        return "number: {}\n\nrandomReveal ({} bytes): {}\n\nmixHash ({} bytes): {}".format(
-            self.number,
-            len(self.randomReveal),
-            self.randomReveal,
-            len(self.mixHash),
-            self.mixHash,
-        )
-
-
-class BlsPublicKeyInfo:
-    publicKey: bytes
-    pop: bytes
-
-    def __init__(self, publicKey, pop):
-        self.publicKey = publicKey
-        self.pop = pop
-
-
-# A BLSRegistry that supports the interface IKIP-113 (https://github.com/klaytn/kips/blob/main/KIPs/kip-113.md)
-class BLSRegistry:
-    mapping = {}
-
-    def __init__(self):
-        for i, proposerAddr in enumerate(proposerAddrs):
-            pop = bytes(PopSchemeMPL.pop_prove(proposerBLSPrivKeys[i]))
-            self.mapping[proposerAddr] = BlsPublicKeyInfo(
-                bytes(proposerBLSPublicKeys[i]), pop
-            )
-
-    def getInfo(self, addr: str) -> BlsPublicKeyInfo:
-        return self.mapping[addr]
-
-
-def is_xxxx_fork_enabled(num):
-    return FORK_BLOCK <= num
-
-
-# dummy function for fetching the proposer secret key
-# in implementation, this should be fetched from a file
-def get_proposer_sk(num):
-    proposerIdx = num % validatorNum
-    return proposerBLSPrivKeys[proposerIdx]
-
-
-def gen_next_header(parent) -> Header:
-    nextBlockNum = parent.number + 1
-    if is_xxxx_fork_enabled(nextBlockNum):
-        sk = get_proposer_sk(nextBlockNum)
-
-        randomReveal = calc_random_reveal(sk, nextBlockNum)
-
-        if nextBlockNum == FORK_BLOCK:
-            # parent mixHash does not exist, so fill with default
-            parentMixHash = b"\x00" * 32
-        else:
-            parentMixHash = parent.mixHash
-
-        mixHash = calc_mix_hash(parentMixHash, randomReveal)
+    if newHeader.number == FORK_BLOCK:
+        prevMixHash =  DEFAULT_MIXHASH
     else:
-        randomReveal = b""
-        mixHash = b""
+        prevMixHash = prevHeader.mixHash
+    newHeader.mixHash = calc_mix_hash(prevMixHash, newHeader.randomReveal)
 
-    return Header(nextBlockNum, randomReveal, mixHash)
+def calc_random_reveal(privateKey, headerNumber):
+    return sign(privateKey, headerNumber)
 
+def calc_mix_hash(prevMixHash, randomReveal):
+    return xor(prevMixHash, keccak256(randomReveal))
 
-def keccak256(msg):
-    keccak256 = keccak.new(digest_bits=256)
-    keccak256.update(msg)
-    return keccak256.digest()
-
-
-def block_num_to_bytes(num) -> bytes:
-    return num.to_bytes(8, byteorder="big")
-
-
-def calc_random_reveal(sk, num) -> bytes:
-    msg = block_num_to_bytes(num)
-    return bytes(PopSchemeMPL.sign(sk, msg))
-
-
-def calc_mix_hash(parentMixHash, randomReveal):
-    return xor(parentMixHash, keccak256(randomReveal))
-
-
-def xor(a: bytes, b: bytes):
-    return bytes(x ^ y for x, y in zip(a, b))
-
-
-def verify_xxxx_header(header, parentMixHash):
-    if not is_xxxx_fork_enabled(header.number):
-        return True
-
+def verify_kip114_header(header, prevHeader):
+    [proposerPubkey, proposerPop] = getProposerPubkeyPop()
     # pop verify
-    blsPublicKeyInfo = BLSRegistry().getInfo(header.proposer)
-    publicKey = G1Element.from_bytes(blsPublicKeyInfo.publicKey)
-    pop = G2Element.from_bytes(blsPublicKeyInfo.pop)
-    if not PopSchemeMPL.pop_verify(publicKey, pop):
-        return False
+    pop_verify(proposerPubkey, proposerPop)
 
-    # sig verify
-    msg = block_num_to_bytes(header.number)
-    sig = G2Element.from_bytes(header.randomReveal)
-    if not PopSchemeMPL.verify(publicKey, msg, sig):
+    # signature verify
+    if not verify(proposerPubkey, header.number, header.randomReveal):
         return False
 
     # mixHash verify
     if header.number == FORK_BLOCK:
-        # parent mixHash does not exist, so fill with default
-        parentMixHash = b"\x00" * 32
-    mixHash = calc_mix_hash(parentMixHash, header.randomReveal)
-    return mixHash == header.mixHash
-
-
-def main():
-    header = Header(FORK_BLOCK - 2, b"\x04" * 96, b"\x00" * 32)
-    prevHeader = header
-    N = 10
-    # print header numbers in [FORK_BLOCK - 1, FORK_BLOCK + N]
-    for _ in range(N + 2):
-        header = gen_next_header(header)
-        print(header)
-        verified = verify_xxxx_header(header, prevHeader.mixHash)
-        assert verified
-        print("verified:", verified)
-        print("=" * 80)
-        prevHeader = header
-
-
-main()
+        prevMixHash = DEFAULT_MIXHASH
+    else:
+        prevMixHash = prevHeader.mixHash
+    return header.mixHash == calc_mix_hash(prevMixHash, header.randomReveal):
 ```
 
 ### Genesis Block
@@ -312,6 +185,173 @@ def find(N, C, threshold):
     for x in range(10000000):
         if f(x, N, C) < threshold:
             return x
+```
+
+## Implementation
+
+A simpulation in Python:
+
+```python
+from blspy import PrivateKey, G1Element, G2Element, PopSchemeMPL  # blspy
+from Crypto.Hash import keccak  # pycryptodome
+
+FORK_BLOCK = 100  # TBD
+DEFAULT_MIXHASH = b"\x00" * 32
+
+validatorNum: int = 3
+proposerBLSPrivKeys: list[PrivateKey] = [
+    PrivateKey.from_bytes((i + 1).to_bytes(32, byteorder="big"))
+    for i in range(validatorNum)
+]  # b"\x00..\x01", b"\x00..\x02", ...
+proposerBLSPublicKeys: list[G1Element] = [i.get_g1() for i in proposerBLSPrivKeys]
+proposerAddrs: list[str] = [
+    str(i + 1).zfill(40) for i in range(validatorNum)
+]  # "0x00..1, 0x00..2, ..."
+
+
+# Block header. Only relevant fields are shown here.
+class Header:
+    number: int = 0  # Block number
+    randomReveal: bytes
+    mixHash: bytes
+    proposer: str
+
+    def __init__(self, number: int, randomReveal: bytes = b"", mixHash: bytes = b""):
+        self.number = number
+        self.randomReveal = randomReveal
+        self.mixHash = mixHash
+        self.proposer = proposerAddrs[number % validatorNum]
+
+    def __repr__(self):
+        return "number: {}\n\nrandomReveal ({} bytes): {}\n\nmixHash ({} bytes): {}".format(
+            self.number,
+            len(self.randomReveal),
+            self.randomReveal,
+            len(self.mixHash),
+            self.mixHash,
+        )
+
+
+class BlsPublicKeyInfo:
+    publicKey: bytes
+    pop: bytes
+
+    def __init__(self, publicKey, pop):
+        self.publicKey = publicKey
+        self.pop = pop
+
+
+# A BLSRegistry that supports the interface IKIP-113 (https://github.com/klaytn/kips/blob/main/KIPs/kip-113.md)
+class BLSRegistry:
+    mapping = {}
+
+    def __init__(self):
+        for i, proposerAddr in enumerate(proposerAddrs):
+            pop = bytes(PopSchemeMPL.pop_prove(proposerBLSPrivKeys[i]))
+            self.mapping[proposerAddr] = BlsPublicKeyInfo(
+                bytes(proposerBLSPublicKeys[i]), pop
+            )
+
+    def getInfo(self, addr: str) -> BlsPublicKeyInfo:
+        return self.mapping[addr]
+
+
+def is_kip114_fork_enabled(num):
+    return FORK_BLOCK <= num
+
+
+# dummy function for fetching the proposer secret key
+# in implementation, this should be fetched from a file
+def get_proposer_private_key(num):
+    proposerIdx = num % validatorNum
+    return proposerBLSPrivKeys[proposerIdx]
+
+
+def fill_kip114_header(newHeader, prevHeader, privateKey):
+    newHeader.randomReveal = calc_random_reveal(privateKey, newHeader.number)
+
+    if newHeader.number == FORK_BLOCK:
+        prevMixHash = DEFAULT_MIXHASH
+    else:
+        prevMixHash = prevHeader.mixHash
+    newHeader.mixHash = calc_mix_hash(prevMixHash, newHeader.randomReveal)
+
+
+def calc_random_reveal(sk, num) -> bytes:
+    msg = block_num_to_bytes(num)
+    return bytes(PopSchemeMPL.sign(sk, msg))
+
+
+def calc_mix_hash(prevMixHash, randomReveal):
+    return xor(prevMixHash, keccak256(randomReveal))
+
+
+def gen_next_header(prevHeader) -> Header:
+    nextBlockNum = prevHeader.number + 1
+    newHeader = Header(nextBlockNum)
+    if is_kip114_fork_enabled(nextBlockNum):
+        privateKey = get_proposer_private_key(nextBlockNum)
+        fill_kip114_header(newHeader, prevHeader, privateKey)
+
+    return newHeader
+
+
+def keccak256(msg):
+    keccak256 = keccak.new(digest_bits=256)
+    keccak256.update(msg)
+    return keccak256.digest()
+
+
+def block_num_to_bytes(num) -> bytes:
+    return num.to_bytes(8, byteorder="big")
+
+
+def xor(a: bytes, b: bytes):
+    return bytes(x ^ y for x, y in zip(a, b))
+
+
+def verify_kip114_header(header, prevHeader):
+    if not is_kip114_fork_enabled(header.number):
+        return True
+
+    # pop verify
+    blsPublicKeyInfo = BLSRegistry().getInfo(header.proposer)
+    publicKey = G1Element.from_bytes(blsPublicKeyInfo.publicKey)
+    pop = G2Element.from_bytes(blsPublicKeyInfo.pop)
+    if not PopSchemeMPL.pop_verify(publicKey, pop):
+        return False
+
+    # signature verify
+    msg = block_num_to_bytes(header.number)
+    sig = G2Element.from_bytes(header.randomReveal)
+    if not PopSchemeMPL.verify(publicKey, msg, sig):
+        return False
+
+    # mixHash verify
+    if header.number == FORK_BLOCK:
+        # prevHeader mixHash does not exist, so fill with default
+        prevMixHash = DEFAULT_MIXHASH
+    else:
+        prevMixHash = prevHeader.mixHash
+    return header.mixHash == calc_mix_hash(prevMixHash, header.randomReveal)
+
+
+def main():
+    header = Header(FORK_BLOCK - 2)
+    prevHeader = header
+    N = 10
+    # print header numbers in [FORK_BLOCK - 1, FORK_BLOCK + N]
+    for _ in range(N + 2):
+        header = gen_next_header(header)
+        print(header)
+        verified = verify_kip114_header(header, prevHeader)
+        assert verified
+        print("verified:", verified)
+        print("=" * 80)
+        prevHeader = header
+
+
+main()
 ```
 
 ## References


### PR DESCRIPTION
KIP-114 is a proposal for signature-based random in block headers.
[See this PR in markdown](https://github.com/klaytn/kips/blob/kip114/KIPs/kip-114.md)
Closes #114 