### PR TITLE
[KIP-113] An interface compatible with CandidateList

### DIFF
--- a/KIPs/kip-113.md
+++ b/KIPs/kip-113.md
@@ -19,7 +19,7 @@ This standard defines an interface for BLS12-381 registry, which enables nodes o
 
 ## Motivation
 
-A standard interface allows developers to associate an address with a BLS public key, and provides a standardized way of interacting with the registry. The objective is to design a simple registry that includes essential functions, and minimal access control, thereby reducing any potential security risks.
+A standard interface allows developers to associate an address with a BLS public key. The objective is to design a simple registry interface, enabling Klaytn nodes to read BLS keys, each of which is associated with a node ID.
 
 ## Specification
 
@@ -42,33 +42,10 @@ interface IKIP113 {
         ///  with ciphersuite "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_"
         bytes pop;
     }
-    event PubkeyRegistered(address addr, bytes publicKey, bytes pop);
-    event PubkeyUnregistered(address addr, bytes publicKey, bytes pop);
-
-    /// @dev Registers the given public key associated with the `msg.sender` address.
-    ///  The function validates the following requirements:
-    ///  - The function MUST revert if `publicKey.length != 48` or `pop.length != 96`.
-    ///  - The function MUST revert if `publicKey` or `pop` is equal to zero.
-    ///  - The function SHOULD authenticate and authorize `msg.sender`.
-    ///  The function emits a `PubkeyRegistered` event.
-    ///  _Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](https://kips.klaytn.foundation/KIPs/kip-113#validation) for off-chain validation.
-    function registerPublicKey(bytes calldata publicKey, bytes calldata pop) external;
-
-    /// @dev Unregisters the public key associated with the given `addr` address.
-    ///  The function validates the following requirements:
-    ///  - The function MUST revert if `addr` has not been registered.
-    ///  - The function SHOULD authenticate and authorize `msg.sender`.
-    ///  The function emits a `PubkeyUnregistered` event.
-    function unregisterPublicKey(address addr) external;
-
-    /// @dev Returns the public key and proof-of-possession given a `addr`.
-    ///  The function MUST revert if given `addr` is not registered.
-    ///  _Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](https://kips.klaytn.foundation/KIPs/kip-113#validation) for off-chain validation.
-    function getInfo(address addr) external view returns (BlsPublicKeyInfo memory pubkey);
 
     /// @dev Returns all the stored addresses, public keys, and proof-of-possessions at once.
     ///  _Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](https://kips.klaytn.foundation/KIPs/kip-113#validation) for off-chain validation.
-    function getAllInfo() external view returns (address[] memory addrList, BlsPublicKeyInfo[] memory pubkeyList);
+    function getAllBlsInfo() external view returns (address[] memory nodeIdList, BlsPublicKeyInfo[] memory pubkeyList);
 }
 ```
 
@@ -81,74 +58,27 @@ The terms public key and proof-of-possession (hereinafter referred to as pop) ar
 
 ### Smart Contracts Overview
 
-The proposed smart contract will be implemented in Solidity and will be compatible with the Ethereum Virtual Machine (EVM).
+The proposed smart contract must be implemented in Solidity and must be compatible with the Ethereum Virtual Machine (EVM).
 
-The smart contract will have the following features:
+The smart contract must have the following features:
 
-- Register a public key and a proof-of-possession
-- Unregister a public key
 - View the registered public keys
 
 #### Methods
 
-##### registerPublicKey
-
-Registers the given public key associated with the `msg.sender` address. This function can be called whether `msg.sender` has already registered a public key or not.
-
-The function validates the following requirements:
-
-- The function MUST revert if `publicKey.length != 48` or `pop.length != 96`.
-- The function MUST revert if `publicKey` or `pop` is equal to zero.
-- The function SHOULD authenticate and authorize `msg.sender`.
-
-The function emits a `PubkeyRegistered` event.
-
-_Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](#validation) for off-chain validation.
-
-```solidity
-function registerPublicKey(bytes memory publicKey, bytes memory pop)
-```
-
-##### unregisterPublicKey
-
-Unregisters the public key associated with the given `addr` address.
-
-The function validates the following requirements:
-
-- The function MUST revert if `addr` has not been registered.
-- The function SHOULD authenticate and authorize `msg.sender`.
-
-The function emits a `PubkeyUnregistered` event.
-
-```solidity
-function unregisterPublicKey(address addr)
-```
-
-##### getInfo
-
-Returns the public key and proof-of-possession given a `addr`.
-
-The function MUST revert if given `addr` is not registered.
-
-_Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](#validation) for off-chain validation.
-
-```solidity
-function getInfo(address addr) external view returns (BlsPublicKeyInfo pubkey)
-```
-
-##### getAllInfo
+##### getAllBlsInfo
 
 Returns all the stored addresses, public keys, and proof-of-possessions at once.
 
-_Note_ The function is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](#validation) for off-chain validation.
+_Note_ The contract is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](#validation) for off-chain validation.
 
 ```solidity
-function getAllInfo() external view returns (address[] addrList, BlsPublicKeyInfo[])
+function getAllBlsInfo() external view returns (address[] addrList, BlsPublicKeyInfo[])
 ```
 
 #### Validation
 
-After reading from Registry, users must perform the following validations:
+After reading from IKIP113, users must perform the following validations:
 
 - [KeyValidate](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-2.5)
 - [PopVerify](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-3.3.3)

--- a/KIPs/kip-113.md
+++ b/KIPs/kip-113.md
@@ -73,7 +73,7 @@ Returns all the stored addresses, public keys, and proof-of-possessions at once.
 _Note_ The contract is not able to verify the validity of the public key and the proof-of-possession due to the lack of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). See [validation](#validation) for off-chain validation.
 
 ```solidity
-function getAllBlsInfo() external view returns (address[] addrList, BlsPublicKeyInfo[])
+function getAllBlsInfo() external view returns (address[] nodeIdList, BlsPublicKeyInfo[] pubkeyList)
 ```
 
 #### Validation


### PR DESCRIPTION
Make the interface compatible with CandidateList.
This facilitates migration from SimpleBLSRegistry to CandidateList, as the consensus logic of Klaytn nodes need not change.