### PR TITLE
[KIP-114] block number is serialized to 32 bytes

### DIFF
--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -319,7 +319,7 @@ def keccak256(msg) -> bytes:
 
 
 def block_num_to_bytes(num) -> bytes:
-    return num.to_bytes(8, byteorder="big")
+    return num.to_bytes(32, byteorder="big")
 
 
 def xor(a: bytes, b: bytes) -> bytes:
@@ -368,6 +368,32 @@ def main():
 
 
 main()
+```
+
+## Test Cases
+
+```
+Proposer secret key:   0x6c605527c8e4f31c959478801d51384d690a22dfc6438604646f7709032c893a
+Previous MixHash:      0x8019df1a2a9f833dc7f400a15b33e54a5c80295165c5953dc23891aab9203810
+Block number:          31337
+Expected Msg:          0x0000000000000000000000000000000000000000000000000000000000007a69
+Expected RandomReveal: 0xadfe25ced45819332cbf088f01cdd2807686dd6309b11d7440237dd623624f401d4753747f5fb92374235e997edcd18318bae2806a1675b1e685e792abd1fbdf5c50ec1e148cc7fe861984d8bc3204c1b2136725b
+Expected MixHash:      0x8772d58248bdf34e81ecbf36f28299cfa758b61ccf3f64e1dc0646687a55892f
+```
+
+Testing the Python simulation above:
+
+```
+sk = PrivateKey.from_bytes(unhexlify("6c605527c8e4f31c959478801d51384d690a22dfc6438604646f7709032c893a"))
+prevMix = unhexlify("8019df1a2a9f833dc7f400a15b33e54a5c80295165c5953dc23891aab9203810")
+num = 31337
+
+msg = block_num_to_bytes(num)
+reveal = calc_random_reveal(sk, num)
+mix = calc_mix_hash(prevMix, reveal)
+assert hexlify(msg) == b"0000000000000000000000000000000000000000000000000000000000007a69"
+assert hexlify(reveal) == b"adfe25ced45819332cbf088f01cdd2807686dd6309b11d7440237dd623624f401d4753747f5fb92374235e997edcd18318bae2806a1675b1e685e792abd1fbdf5c50ec1e148cc7fe861984d8bc3204c1b2136725b
+assert hexlify(mix) == b"8772d58248bdf34e81ecbf36f28299cfa758b61ccf3f64e1dc0646687a55892f"
 ```
 
 ## References

--- a/KIPs/kip-114.md
+++ b/KIPs/kip-114.md
@@ -145,7 +145,7 @@ def verify_kip114_header(newHeader, prevHeader):
 
 ### EVM
 
-Beginning with `FORK_BLOCK`, the `RANDOM (0x44)` instruction must return the value of `mixHash` of the latest block.
+Beginning with `FORK_BLOCK`, the `RANDOM (0x44)` instruction must return the value of `mixHash` of the current block it is executing in.
 
 Note: The gas cost of the `RANDOM (0x44)` opcode remains unchanged.
 


### PR DESCRIPTION
Modify KIP-114 spec's implementation detail.
- Change `block_number_to_bytes()` from an 8-byte big-endian bytes to a 32-byte big-endian bytes.
- Add a test case to check implementation correctness.
- Change `RANDOM` opcode semantic to return the current block's, not latest block's.

Reason
- In Go implementation, passing message other than 32-bytes is inconvenient because Klaytn's [`bls.VerifySignature`](https://github.com/klaytn/klaytn/blob/dev/crypto/bls/bls.go) expects 32 bytes message (following the [Prysm's convention](https://github.com/prysmaticlabs/prysm/blob/develop/crypto/bls/bls.go))