### PR TITLE
Add query APIs for KIP113, KIP149

### DIFF
--- a/KIPs/kip-113.md
+++ b/KIPs/kip-113.md
@@ -96,7 +96,7 @@ The following JSON-RPC method for the Klaytn node should be added to provide the
     - `pop` - The proof-of-possession in hex string.
     - `verifyErr` - The error message of the verification. If the verification is successful, it returns null.
 * Example
-    ```json
+    ```
     // Request
     curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"klay_getBlsInfos", "params":["latest"],"id":1}' http://localhost:8551
     // Response

--- a/KIPs/kip-113.md
+++ b/KIPs/kip-113.md
@@ -83,6 +83,37 @@ After reading from IKIP113, users must perform the following validations:
 - [KeyValidate](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-2.5)
 - [PopVerify](https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#section-3.3.3)
 
+### JSON-RPC API
+
+The following JSON-RPC method for the Klaytn node should be added to provide the registered bls public keys.
+
+* Name: `klay_getBlsInfos`
+* Description: Returns all registered bls public keys and proof-of-possessions of the validators.
+* Parameters:
+    * `number` - (optional) integer or hexadecimal block number, or the string "pending" or "latest".
+* Returns 
+    * `map[common.Address]BlsPublicKeyInfo`: A map of the addresses and their associated bls public keys, proof-of-possessions and verify error.
+        * `BlsPublicKeyInfo`: A struct of the bls record with the following fields:
+            * `PublicKey` - (string) The compressed BLS12-381 public key in hex string.
+            * `Pop` - (string) The proof-of-possession in hex string.
+            * `VerifyErr` - (error) The error message of the verification. If the verification is successful, it returns null.
+* Example
+    ```json
+    // Request
+    curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"klay_getBlsInfos", "params":["latest"],"id":1}' http://localhost:8551
+    // Response
+    {
+        "jsonrpc":"2.0",
+        "id":1,
+        "result": {
+            "0xa93bf2790a22cd43e3a716739704ec0a05f155f8":{
+                "PublicKey":"a5b8ca9ff597312c1c5bf1d95c694e5adc4cd86c1219cf4c17aec4c858fb0d89e794bfc740121c6ad1ab5fd9e4c2cdd6",
+                "Pop":"a4a453712111f03b5ee4a1d407590573805db48d6050a9461a94c555779ee555c8a89386802eae8cd90708728cccfdde0be95230c55438084c80865bfff47bb381c5e60aaeab6d3d355e36645307f0065d5dd80e544eed00fddfcdd94f3402ca",
+                "VerifyErr":null
+            }
+        }
+    }
+    ```
 ## Backwards Compatibility
 
 This does not affect the backward compatibility as this is a newly deployed contract.

--- a/KIPs/kip-113.md
+++ b/KIPs/kip-113.md
@@ -87,16 +87,14 @@ After reading from IKIP113, users must perform the following validations:
 
 The following JSON-RPC method for the Klaytn node should be added to provide the registered bls public keys.
 
-* Name: `klay_getBlsInfos`
-* Description: Returns all registered bls public keys and proof-of-possessions of the validators.
-* Parameters:
-    * `number` - (optional) integer or hexadecimal block number, or the string "pending" or "latest".
-* Returns 
-    * `map[common.Address]BlsPublicKeyInfo`: A map of the addresses and their associated bls public keys, proof-of-possessions and verify error.
-        * `BlsPublicKeyInfo`: A struct of the bls record with the following fields:
-            * `PublicKey` - (string) The compressed BLS12-381 public key in hex string.
-            * `Pop` - (string) The proof-of-possession in hex string.
-            * `VerifyErr` - (error) The error message of the verification. If the verification is successful, it returns null.
+- Name: `klay_getBlsInfos`
+- Description: Returns all registered bls public keys and proof-of-possessions of the validators.
+- Parameters:
+    - `number` - (optional) integer or hexadecimal block number, or the string "pending" or "latest".
+- Returns: A map of the addresses and their associated bls public keys, proof-of-possessions and verify error.
+    - `publicKey` - The compressed BLS12-381 public key in hex string.
+    - `pop` - The proof-of-possession in hex string.
+    - `verifyErr` - The error message of the verification. If the verification is successful, it returns null.
 * Example
     ```json
     // Request
@@ -105,11 +103,21 @@ The following JSON-RPC method for the Klaytn node should be added to provide the
     {
         "jsonrpc":"2.0",
         "id":1,
-        "result": {
-            "0xa93bf2790a22cd43e3a716739704ec0a05f155f8":{
-                "PublicKey":"a5b8ca9ff597312c1c5bf1d95c694e5adc4cd86c1219cf4c17aec4c858fb0d89e794bfc740121c6ad1ab5fd9e4c2cdd6",
-                "Pop":"a4a453712111f03b5ee4a1d407590573805db48d6050a9461a94c555779ee555c8a89386802eae8cd90708728cccfdde0be95230c55438084c80865bfff47bb381c5e60aaeab6d3d355e36645307f0065d5dd80e544eed00fddfcdd94f3402ca",
-                "VerifyErr":null
+        "result":{
+            "0x18a80d0d3a8b7348277c497105cc2163b242799a":{
+                "publicKey":"8247754efd7aa2b02b30b6db8e1c24bb8c4207f5600470c2dafde1b46270a6c8c3fe9e7f8b939965d6a59dbe2ebd0cf7",
+                "pop":"8c35987399eab7a98ad24e869a7d7225bdb95203167e6aa20b3db73c0a91317e805e48d33c606484b1e9db3d8c8d64b60f0c6a8816b219f43747bf201dd65193ade23434270c78441e370a95d7632a6a76f1f3a62842425f76ebc4a041fc1dbb",
+                "verifyErr":null
+            },
+            "0x527d6d61f53305c1e1d3680b23393c3c13c8db9e":{
+                "publicKey":"a16153b81453a9e3099728ff1d3aac3d3fca32b3594407277ec0b8df4aa66cba743916d9f2098707aecc350954b0cd4e",
+                "pop":"a92c7ba586a12a38e3a7bbfed7f7a311664cb0dc66a7bd26ee79bed4755e7652850dff1cfabf39acd58ea8efe24ff7c217f1d5c2ac3fe948016056e99b03bc26aa8c59b89cfc9ee961bf8cfd1802295d4ff07852f93d0607a53655f15665aad9",
+                "verifyErr":null
+            },
+            "0xa72ccdf72dc401df79805013a42b74f12b43caa1":{
+                "publicKey":"883eb2c623a19671461bc0dadcfa17384198ff06b2e2c9cd1ca539ff554c377256624e9f5f69d27e17e4635080938d9a",
+                "pop":"ac1bb19588b2ec7e1452486b8a4afe0ecb27847bca04b7e4919a9d6b70c1342dcfb1a6983788d3756607b84d3d7a009118246ed5b3b3449638e591ab9fe2c4ec5cafb64ddc12a5dcf48cbcf305175d5dddb48845e80f7cb9a32d5f2e67ca2163",
+                "verifyErr":null
             }
         }
     }

--- a/KIPs/kip-113.md
+++ b/KIPs/kip-113.md
@@ -85,13 +85,13 @@ After reading from IKIP113, users must perform the following validations:
 
 ### JSON-RPC API
 
-The following JSON-RPC method for the Klaytn node should be added to provide the registered bls public keys.
+The following JSON-RPC method for the Klaytn node should be added to provide the registered BLS public keys.
 
 - Name: `klay_getBlsInfos`
-- Description: Returns all registered bls public keys and proof-of-possessions of the validators.
+- Description: Returns all registered BLS public keys and proof-of-possessions of the validators.
 - Parameters:
     - `number` - (optional) integer or hexadecimal block number, or the string "pending" or "latest".
-- Returns: A map of the addresses and their associated bls public keys, proof-of-possessions and verify error.
+- Returns: A map of the addresses and their associated BLS public keys, proof-of-possessions and verify error.
     - `publicKey` - The compressed BLS12-381 public key in hex string.
     - `pop` - The proof-of-possession in hex string.
     - `verifyErr` - The error message of the verification. If the verification is successful, it returns null.

--- a/KIPs/kip-149.md
+++ b/KIPs/kip-149.md
@@ -254,8 +254,7 @@ The following JSON-RPC methods for the Klaytn node should be added to provide th
         - `name`: the name of the system contract in string.
         - `number`: (optional) integer or hexadecimal block number, or the string "pending" or "latest".
     - Description: Returns the active address of the system contract registered as `name` if exists.
-    - Returns:
-        - `address`: The address of the active system contract.
+    - Return: The address of the active system contract.
     - Example
         ```json
         // Request
@@ -288,8 +287,8 @@ The following JSON-RPC methods for the Klaytn node should be added to provide th
     - Returns:
         - `Record[]`: An array of the records of the system contract.
             - `Record`: A struct of the record with the following fields.
-                - `Addr`: The address of the system contract.
-                - `Activation`: The block number when the system contract will be activated.
+                - `addr`: The address of the system contract.
+                - `activation`: The block number when the system contract will be activated.
     - Example
         ```json
         // Request
@@ -300,8 +299,8 @@ The following JSON-RPC methods for the Klaytn node should be added to provide th
             "id":1,
             "result":[
                 {
-                    "Addr":"0x0000000000000000000000000000000000000402",
-                    "Activation":0
+                    "addr":"0x0000000000000000000000000000000000000402",
+                    "activation":0
                 }
             ]
         }

--- a/KIPs/kip-149.md
+++ b/KIPs/kip-149.md
@@ -288,7 +288,7 @@ The following JSON-RPC methods for the Klaytn node should be added to provide th
         - `Record[]`: An array of the records of the system contract.
             - `Record`: A struct of the record with the following fields.
                 - `addr`: The address of the system contract.
-                - `activation`: The block number when the system contract will be activated.
+                - `activation`: The block number when the system contract is activated.
     - Example
         ```json
         // Request

--- a/KIPs/kip-149.md
+++ b/KIPs/kip-149.md
@@ -290,7 +290,7 @@ The following JSON-RPC methods for the Klaytn node should be added to provide th
                 - `addr`: The address of the system contract.
                 - `activation`: The block number when the system contract is activated.
     - Example
-        ```json
+        ```
         // Request
         curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"klay_getAllRecordsFromRegistry", "params":["KIP113", "latest"],"id":1}' http://localhost:8551
         // Response

--- a/KIPs/kip-149.md
+++ b/KIPs/kip-149.md
@@ -244,6 +244,81 @@ func ReadActiveAddressFromRegistry(backend bind.ContractCaller, name string, num
 }
 ```
 
+#### JSON-RPC APIs
+
+The following JSON-RPC methods for the Klaytn node should be added to provide the records of registered system contracts.
+
+1. `klay_getActiveAddressFromRegistry`
+
+    - Parameters:
+        - `name`: the name of the system contract in string.
+        - `number`: (optional) integer or hexadecimal block number, or the string "pending" or "latest".
+    - Description: Returns the active address of the system contract registered as `name` if exists.
+    - Returns:
+        - `address`: The address of the active system contract.
+    - Example
+        ```json
+        // Request
+        curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"klay_getActiveAddressFromRegistry", "params":["KIP113", "latest"],"id":1}' http://localhost:8551
+        // Response
+        {
+            "jsonrpc":"2.0",
+            "id":1,
+            "result": "0x0000000000000000000000000000000000000402"
+        }
+
+        // Request - no active system contract
+        curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"klay_getActiveAddressFromRegistry", "params":["KIP114", "latest"],"id":1}' http://localhost:8551
+        // Response
+        {
+            "jsonrpc":"2.0",
+            "id":1,
+            "error":{
+                "code":-32000,
+                "message":"no active address for KIP114"
+            }
+        }
+        ```
+2. `klay_getAllRecordsFromRegistry`
+
+    - Parameters:
+        - `name`: the name of the system contract in string.
+        - `number`: (optional) integer or hexadecimal block number, or the string "pending" or "latest".
+    - Description: Returns all records of the system contract registered as `name` if it has been registered.
+    - Returns:
+        - `Record[]`: An array of the records of the system contract.
+            - `Record`: A struct of the record with the following fields.
+                - `Addr`: The address of the system contract.
+                - `Activation`: The block number when the system contract will be activated.
+    - Example
+        ```json
+        // Request
+        curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"klay_getAllRecordsFromRegistry", "params":["KIP113", "latest"],"id":1}' http://localhost:8551
+        // Response
+        {
+            "jsonrpc":"2.0",
+            "id":1,
+            "result":[
+                {
+                    "Addr":"0x0000000000000000000000000000000000000402",
+                    "Activation":0
+                }
+            ]
+        }
+
+        // request - no records
+        curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"klay_getAllRecordsFromRegistry", "params":["KIP114", "latest"],"id":1}' http://localhost:8551
+        // Response
+        {
+            "jsonrpc":"2.0",
+            "id":1,
+            "error":{
+                "code":-32000,
+                "message":"KIP114 has not been registered"
+            }
+        }
+        ```
+
 ## Rationale
 
 ### Bytecode Injection for Registry Deployment


### PR DESCRIPTION
* Add query APIs for KIP113, KIP149.
1. KIP113
    - `klay_getBlsInfos`: Returns all registered BLS records in `SImpleBlsRegistry` contract (KIP113)

2. KIP149
    - `klay_getAllRecordsFromRegistry`: Returns all registered records in `Registry` contract (KIP14)
    - `klay_getActiveAddressFromRegistry`: Returns active address in `Registry` contract if exists

Any suggestions for improvements are welcome.