### PR TITLE
Update memo format rebalance

### DIFF
--- a/KIPs/kip-103.md
+++ b/KIPs/kip-103.md
@@ -168,11 +168,11 @@ The execution result of treasury fund rebalancing will be printed as an INFO-lev
 **Format**
 
 ```
-{
-  "retired": {"0xRetiredAddress1":[removed balance in Peb], "0xRetiredAddress2":[removed balance in Peb], ... },
-  "newbie" {"0xNewbieAddress1":[new allocated balance in Peb], "0xNewbieAddress2":[new allocated balance in Peb], ... },,
-  "burnt":[bunt amount in Peb],
-  "success":true
+  {
+    "retirees": [ { "retired": "0xRetiredAddress1", "balance": [removed balance in Peb] }, { "retired": "0xRetiredAddress2", "balance": removed balance in Peb], ... } ],
+    "newbies": [ { "newbie": "0xNewbieAddress1", "fundAllocated": [new allocated balance in Peb] }, { "newbie": "0xNewbieAddress2", "fundAllocated": [new allocated balance in Peb], ... } ],
+    "burnt": [bunt amount in Peb],
+    "success": true
 }
 ```
 
@@ -182,11 +182,20 @@ Note: 10^18 [Peb](https://docs.klaytn.foundation/content/klaytn/design/klaytn-na
 
 ```
 memo="{
-  "retired": {"0x38138d89c321b3b5f421e9452b69cf29e4380bae":117000000000000000000000000000000000000, "0x30208f32c70e8b53a67ea171c8720cbfe32888ff":117000000000000000000000000000000000000},
-  "newbie" {"0x0a33a1b99bd67a7189573dd74de80293afdf969a":22500000000000000000000000000000000000, "0xd9de2697000c3665e9c5a71e1bf52aaa44507cc0":22500000000000000000000000000000000000},
-  "burnt":72000000000000000000000000000000000000,
+  "retirees":[
+    {"retired":"0xafd197d383453b08b7c1509bdb4b6afee9f66578","balance":5000000001892521406055074536},
+    {"retired":"0x5678300abc1f599d865c3525df851b3902c88266","balance":2280917577134567890000000000},
+    {"retired":"0x278e6332d69eed782784d21802e3504a64a16456","balance":352628334320754365571158456},
+    {"retired":"0x3d803a7375a8ee5996f52a8d6725637a89f5bbf8","balance":112778356560412760866604672}
+  ],
+  "newbies":[
+    {"newbie":"0x4f04251064274252d27d4af55bc85b68b3add992","fundAllocated":2000000000000000000000000000},
+    {"newbie":"0x85d82d811743b4b8f3c48f3e48a1664d1ffc2c10","fundAllocated":180000000000000000000000000},
+    {"newbie":"0xdd4c8d805fc110369d3b148a6692f283ffbdccd3","fundAllocated":270000000000000000000000000}
+  ],
+  "burnt":5296324269908256422492837664,
   "success":true
-}"
+}
 ```
 
 ## Rationale
@@ -224,10 +233,8 @@ Query Result:
 
 ```js
 memo= "{
-  "retirees": [{"retired": "0xRetiredAddress1", "balance": "0xamount"},
-    {"retired": "0xRetiredAddress2", "balance": "0xamount"}],
-  "newbies": [{"newbie": "0xNewbieAddress1", "fundAllocated": "0xamount"},
-    {"newbie": "0xNewbieAddress2","fundAllocated": "0xamount"}],
+  "retirees": [{"retired": "0xRetiredAddress1", "balance": "0xamount"}, {"retired": "0xRetiredAddress2", "balance": "0xamount"}, ...],
+  "newbies": [{"newbie": "0xNewbieAddress1", "fundAllocated": "0xamount"}, {"newbie": "0xNewbieAddress2","fundAllocated": "0xamount"}, ...],
   "burnt": "0xamount",
   "success": true
 }"

--- a/KIPs/kip-103.md
+++ b/KIPs/kip-103.md
@@ -171,8 +171,8 @@ The execution result of treasury fund rebalancing will be printed as an INFO-lev
   {
     "retirees": [ { "retired": "0xRetiredAddress1", "balance": [removed balance in Peb] }, { "retired": "0xRetiredAddress2", "balance": removed balance in Peb], ... } ],
     "newbies": [ { "newbie": "0xNewbieAddress1", "fundAllocated": [new allocated balance in Peb] }, { "newbie": "0xNewbieAddress2", "fundAllocated": [new allocated balance in Peb], ... } ],
-    "burnt": [bunt amount in Peb],
-    "success": true
+    "burnt": [burnt amount in Peb],
+    "success": [true/false]
 }
 ```
 

--- a/KIPs/kip-160.md
+++ b/KIPs/kip-160.md
@@ -16,7 +16,7 @@ An update of treasury fund rebalancing.
 The treasury fund rebalancing is updated, resulting in updates to the treasury rebalance contract v2 and the related core logic.
 
 ## Motivation
-According to KIP-103, the treasury rebalancing refers to the act of burning existing fund balances and minting new funds. This event happens at a reserved time, such as a hard fork block number. Through the TreasuryRebalance contract, the disclosure of the treasury fund activities can be conducted transparently and verifiably. However, there are a few shortcomings of KIP-103; (1) it only permits the decrease in the total balance of the funds, (2) its rebalance blocknumber is immutable.
+According to KIP-103, the treasury rebalancing refers to the act of burning existing fund balances and minting new funds. This event happens at a reserved time, such as a hard fork block number. Through the TreasuryRebalance contract, the disclosure of the treasury fund activities can be conducted transparently and verifiably. However, there are a few shortcomings of KIP-103; (1) it only permits the decrease in the total balance of the funds, (2) its rebalance blocknumber or memo is immutable. Once these values are set, they cannot be changed, even if they are incorrectly set.
 
 To address those above, this proposal made some improvements. First of all, this proposal expands to the general cases so that we don't have to consider whether the final result is burn or mint. The other improvement is about making rebalanceBlocknumber in the RebalanceContract editable. The rebalanceBlocknumber should be matched with the related hardfork block number.
 
@@ -65,9 +65,45 @@ The next method is added to the TreasuryRebalanceV2 contract.
     }
 ```
 
+### To enable editing of Memo defined in treasury rebalance contract
+The execution result of treasury fund rebalancing V2 is printed as an INFO-level log on each node. This log is added as a memo to the contract, making it permanently viewable. 
+However, once finalized, any modifications to the memo value were restricted even if set incorrectly.
+This proposal aims to seperate the memo setting process from the contract finalization, allowing the memo value to be set repeatedly.
+
+The `setPendingMemo` is added and `finalizeContract` of the TreasuryRebalanceV2 contract is revised as follows.
+
+```solidity
+    string public pendingMemo; // temporary storage for memo
+    string public memo; // result of the treasury fund rebalance
+
+    /**
+     * @dev sets the pendingMemo of the Contract. Once finalized, the memo cannot be modified.
+     * @param _memo is the result of the rebalance after executing successfully in the core.
+     */
+    function setPendingMemo(string memory _memo) external onlyOwner onlyAtStatus(Status.Approved) {
+        pendingMemo = _memo;
+    }
+
+    /**
+     * @dev sets the status of the contract to Finalize. Once finalized the storage data
+     * of the contract cannot be modified. Also it sets the memo with pendingMemo value.
+     * It will be used for public disclosure.
+     * Can only be called by the current owner at Approved state after the execution of rebalance in the core
+     */
+    function finalizeContract() external onlyOwner onlyAtStatus(Status.Approved) {
+        require(block.number > rebalanceBlockNumber, "Contract can only finalize after executing rebalancing");
+        require(bytes(pendingMemo).length > 0, "no pending memo, cannot finalize without memo");
+
+        memo = pendingMemo;
+        status = Status.Finalized;
+        emit Finalized(memo, status);
+    }
+```
+
 ### Result
-The execution result of treasury fund rebalancing V2 will be printed as an INFO-level log on each node in the format shown below. Then, the treasury rebalance V2 contract should be finalized by adding the log as a memo to the contract. Any modifications to the storage data will be restricted after finalization, the same as with treasury rebalance V1.
-The unit of balance/amount is kei (peb of Klaytn).
+In the Kip-103 memo format, the `zeroed` item showed the balance of the zereods before rebalancing, while the `allocated` item showed the balance of the allocateds after rebalancing. 
+It was insufficient for interpreting the rebalancing results. Therefore, this proposal changes the format to display balances both before and after rebalancing. 
+The newly proposed memo format is shown below with balance/amount in kei (peb of Klaytn).
 
 **Format**
 

--- a/KIPs/kip-160.md
+++ b/KIPs/kip-160.md
@@ -65,6 +65,27 @@ The next method is added to the TreasuryRebalanceV2 contract.
     }
 ```
 
+### Result
+The execution result of treasury fund rebalancing V2 will be printed as an INFO-level log on each node in the format shown below. Then, the treasury rebalance V2 contract should be finalized by adding the log as a memo to the contract. Any modifications to the storage data will be restricted after finalization, the same as with treasury rebalance V1.
+The unit of balance/amount is kwei (peb of Klaytn).
+
+**Format**
+
+```
+{
+  "before": { 
+    "zeroed": { "0xZeroedAddress1": [balance of zeroedAddress1 before rebalance],  "0xZeroedAddress2": [balance of zeroedAddress2 before rebalance], ...},
+    "allocated": {  "0xAllocatedAddress1": [balance of AllocatedAddress1 before rebalance],  "0xAllocatedAddress2": [balance of AllocatedAddress1 before rebalance], ...}
+  },
+  "after": {  
+    zeroed": {  "0xZeroedAddress1": [balance of zeroedAddress1 after rebalance], "0xZeroedAddress2": [balance of zeroedAddress2 after rebalance], ...},
+    "allocated": { "0xAllocatedAddress1": [balance of AllocatedAddress1 after rebalance],  "0xAllocatedAddress2": [balance of AllocatedAddress1 after rebalance], ...}
+  },
+  "burnt": [burnt amount],
+  "success": [true/false]
+}
+```
+
 ## Rationale
 While executing the core logic of the KIP-103 treasury rebalance, the unintended increase in the nonce of the '0x0' address occured. In KIP-160, this issue can be resolved by replacing the usage of `kip103ContractBackend` with `BlockchainContractBackend`. For your reference, `ContractBackend` facilitates the interaction between the core and contracts.
 

--- a/KIPs/kip-160.md
+++ b/KIPs/kip-160.md
@@ -67,7 +67,7 @@ The next method is added to the TreasuryRebalanceV2 contract.
 
 ### Result
 The execution result of treasury fund rebalancing V2 will be printed as an INFO-level log on each node in the format shown below. Then, the treasury rebalance V2 contract should be finalized by adding the log as a memo to the contract. Any modifications to the storage data will be restricted after finalization, the same as with treasury rebalance V1.
-The unit of balance/amount is kwei (peb of Klaytn).
+The unit of balance/amount is kei (peb of Klaytn).
 
 **Format**
 

--- a/KIPs/kip-160.md
+++ b/KIPs/kip-160.md
@@ -1,7 +1,7 @@
 ---
 kip: 160
 title: An Update of Treasury Fund Rebalancing
-author: Yumiel (@yoomee1313) and Ollie (@blukat29)
+author: Ollie (@blukat29), Yumiel (@yoomee1313), Ian (@ian0371), Aidan (@aidan-kwon)
 status: Final
 type: Standards Track
 category: Core


### PR DESCRIPTION
This PR updates memo format of the kip-103 and kip-160 treasury rebalance proposals.
  - kip-103: revise memo format of a Info-log to match with the contract memo format
  - kip-160: add new memo format. The reason of introducing new memo format is to get the additional balance data to calculate burnt amount directly.